### PR TITLE
art: open + setoffset fd instead of copy

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -426,7 +426,7 @@ LOCAL_REQUIRED_MODULES := \
 # * Otherwise, we will add them by default to userdebug and eng builds.
 art_target_include_debug_build := $(PRODUCT_ART_TARGET_INCLUDE_DEBUG_BUILD)
 ifneq (false,$(art_target_include_debug_build))
-ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+ifneq (,$(filter eng,$(TARGET_BUILD_VARIANT)))
   art_target_include_debug_build := true
 endif
 ifeq (true,$(art_target_include_debug_build))

--- a/build/art.go
+++ b/build/art.go
@@ -61,8 +61,8 @@ func globalFlags(ctx android.LoadHookContext) ([]string, []string) {
 	}
 
 	if !ctx.Config().IsEnvFalse("ART_USE_READ_BARRIER") && ctx.Config().ArtUseReadBarrier() {
-		// Used to change the read barrier type. Valid values are BAKER, BROOKS,
-		// TABLELOOKUP. The default is BAKER.
+		// Used to change the read barrier type. Valid values are BAKER, TABLELOOKUP.
+		// The default is BAKER.
 		barrierType := ctx.Config().GetenvWithDefault("ART_READ_BARRIER_TYPE", "BAKER")
 		cflags = append(cflags,
 			"-DART_USE_READ_BARRIER=1",

--- a/compiler/jit/jit_compiler.cc
+++ b/compiler/jit/jit_compiler.cc
@@ -208,5 +208,9 @@ bool JitCompiler::CompileMethod(
   return success;
 }
 
+bool JitCompiler::IsBaselineCompiler() const {
+  return compiler_options_->IsBaseline();
+}
+
 }  // namespace jit
 }  // namespace art

--- a/compiler/jit/jit_compiler.h
+++ b/compiler/jit/jit_compiler.h
@@ -48,6 +48,8 @@ class JitCompiler : public JitCompilerInterface {
     return *compiler_options_.get();
   }
 
+  bool IsBaselineCompiler() const override;
+
   bool GenerateDebugInfo() override;
 
   void ParseCompilerOptions() override;

--- a/compiler/jni/quick/arm/calling_convention_arm.h
+++ b/compiler/jni/quick/arm/calling_convention_arm.h
@@ -67,8 +67,7 @@ class ArmJniCallingConvention final : public JniCallingConvention {
   size_t FrameSize() const override;
   size_t OutFrameSize() const override;
   ArrayRef<const ManagedRegister> CalleeSaveRegisters() const override;
-  ManagedRegister SavedLocalReferenceCookieRegister() const override;
-  ManagedRegister ReturnScratchRegister() const override;
+  ArrayRef<const ManagedRegister> CalleeSaveScratchRegisters() const override;
   uint32_t CoreSpillMask() const override;
   uint32_t FpSpillMask() const override;
   bool IsCurrentParamInRegister() override;

--- a/compiler/jni/quick/arm64/calling_convention_arm64.cc
+++ b/compiler/jni/quick/arm64/calling_convention_arm64.cc
@@ -232,15 +232,17 @@ uint32_t Arm64JniCallingConvention::FpSpillMask() const {
   return is_critical_native_ ? 0u : kFpCalleeSpillMask;
 }
 
-ManagedRegister Arm64JniCallingConvention::SavedLocalReferenceCookieRegister() const {
-  // The w21 is callee-save register in both managed and native ABIs.
-  // It is saved in the stack frame and it has no special purpose like `tr`.
-  static_assert((kCoreCalleeSpillMask & (1u << W21)) != 0u);  // Managed callee save register.
-  return Arm64ManagedRegister::FromWRegister(W21);
-}
-
-ManagedRegister Arm64JniCallingConvention::ReturnScratchRegister() const {
-  return ManagedRegister::NoRegister();
+ArrayRef<const ManagedRegister> Arm64JniCallingConvention::CalleeSaveScratchRegisters() const {
+  DCHECK(!IsCriticalNative());
+  // Use X21-X29 from native callee saves.
+  constexpr size_t kStart = 2u;
+  constexpr size_t kLength = 9u;
+  static_assert(kAapcs64CalleeSaveRegisters[kStart].Equals(
+                    Arm64ManagedRegister::FromXRegister(X21)));
+  static_assert(kAapcs64CalleeSaveRegisters[kStart + kLength - 1u].Equals(
+                    Arm64ManagedRegister::FromXRegister(X29)));
+  static_assert((kAapcs64CoreCalleeSpillMask & ~kCoreCalleeSpillMask) == 0u);
+  return ArrayRef<const ManagedRegister>(kAapcs64CalleeSaveRegisters).SubArray(kStart, kLength);
 }
 
 size_t Arm64JniCallingConvention::FrameSize() const {

--- a/compiler/jni/quick/arm64/calling_convention_arm64.cc
+++ b/compiler/jni/quick/arm64/calling_convention_arm64.cc
@@ -58,8 +58,8 @@ static constexpr ManagedRegister kCalleeSaveRegisters[] = {
 
     // Thread register(X19) is saved on stack.
     Arm64ManagedRegister::FromXRegister(X19),
-    Arm64ManagedRegister::FromXRegister(X20),
-    Arm64ManagedRegister::FromXRegister(X21),
+    Arm64ManagedRegister::FromXRegister(X20),  // Note: Marking register.
+    Arm64ManagedRegister::FromXRegister(X21),  // Note: Suspend check register.
     Arm64ManagedRegister::FromXRegister(X22),
     Arm64ManagedRegister::FromXRegister(X23),
     Arm64ManagedRegister::FromXRegister(X24),
@@ -234,11 +234,11 @@ uint32_t Arm64JniCallingConvention::FpSpillMask() const {
 
 ArrayRef<const ManagedRegister> Arm64JniCallingConvention::CalleeSaveScratchRegisters() const {
   DCHECK(!IsCriticalNative());
-  // Use X21-X29 from native callee saves.
-  constexpr size_t kStart = 2u;
-  constexpr size_t kLength = 9u;
+  // Use X22-X29 from native callee saves.
+  constexpr size_t kStart = 3u;
+  constexpr size_t kLength = 8u;
   static_assert(kAapcs64CalleeSaveRegisters[kStart].Equals(
-                    Arm64ManagedRegister::FromXRegister(X21)));
+                    Arm64ManagedRegister::FromXRegister(X22)));
   static_assert(kAapcs64CalleeSaveRegisters[kStart + kLength - 1u].Equals(
                     Arm64ManagedRegister::FromXRegister(X29)));
   static_assert((kAapcs64CoreCalleeSpillMask & ~kCoreCalleeSpillMask) == 0u);

--- a/compiler/jni/quick/arm64/calling_convention_arm64.h
+++ b/compiler/jni/quick/arm64/calling_convention_arm64.h
@@ -58,8 +58,7 @@ class Arm64JniCallingConvention final : public JniCallingConvention {
   size_t FrameSize() const override;
   size_t OutFrameSize() const override;
   ArrayRef<const ManagedRegister> CalleeSaveRegisters() const override;
-  ManagedRegister SavedLocalReferenceCookieRegister() const override;
-  ManagedRegister ReturnScratchRegister() const override;
+  ArrayRef<const ManagedRegister> CalleeSaveScratchRegisters() const override;
   uint32_t CoreSpillMask() const override;
   uint32_t FpSpillMask() const override;
   bool IsCurrentParamInRegister() override;

--- a/compiler/jni/quick/calling_convention.h
+++ b/compiler/jni/quick/calling_convention.h
@@ -315,12 +315,11 @@ class JniCallingConvention : public CallingConvention {
   // Callee save registers to spill prior to native code (which may clobber)
   virtual ArrayRef<const ManagedRegister> CalleeSaveRegisters() const = 0;
 
-  // Register where the segment state of the local indirect reference table is saved.
-  // This must be a native callee-save register without another special purpose.
-  virtual ManagedRegister SavedLocalReferenceCookieRegister() const = 0;
-
-  // An extra scratch register live after the call
-  virtual ManagedRegister ReturnScratchRegister() const = 0;
+  // Subset of core callee save registers that can be used for arbitrary purposes after
+  // constructing the JNI transition frame. These should be managed callee-saves as well.
+  // These should not include special purpose registers such as thread register.
+  // JNI compiler currently requires at least 3 callee save scratch registers.
+  virtual ArrayRef<const ManagedRegister> CalleeSaveScratchRegisters() const = 0;
 
   // Spill mask values
   virtual uint32_t CoreSpillMask() const = 0;

--- a/compiler/jni/quick/x86/calling_convention_x86.cc
+++ b/compiler/jni/quick/x86/calling_convention_x86.cc
@@ -71,15 +71,12 @@ static constexpr uint32_t kNativeFpCalleeSpillMask = 0u;
 
 // Calling convention
 
-ManagedRegister X86JniCallingConvention::SavedLocalReferenceCookieRegister() const {
-  // The EBP is callee-save register in both managed and native ABIs.
-  // It is saved in the stack frame and it has no special purpose like `tr` on arm/arm64.
-  static_assert((kCoreCalleeSpillMask & (1u << EBP)) != 0u);  // Managed callee save register.
-  return X86ManagedRegister::FromCpuRegister(EBP);
-}
-
-ManagedRegister X86JniCallingConvention::ReturnScratchRegister() const {
-  return ManagedRegister::NoRegister();  // No free regs, so assembler uses push/pop
+ArrayRef<const ManagedRegister> X86JniCallingConvention::CalleeSaveScratchRegisters() const {
+  DCHECK(!IsCriticalNative());
+  // All managed callee-save registers are available.
+  static_assert((kCoreCalleeSpillMask & ~kNativeCoreCalleeSpillMask) == 0u);
+  static_assert(kFpCalleeSpillMask == 0u);
+  return ArrayRef<const ManagedRegister>(kCalleeSaveRegisters);
 }
 
 static ManagedRegister ReturnRegisterForShorty(const char* shorty, bool jni) {

--- a/compiler/jni/quick/x86/calling_convention_x86.h
+++ b/compiler/jni/quick/x86/calling_convention_x86.h
@@ -63,8 +63,7 @@ class X86JniCallingConvention final : public JniCallingConvention {
   size_t FrameSize() const override;
   size_t OutFrameSize() const override;
   ArrayRef<const ManagedRegister> CalleeSaveRegisters() const override;
-  ManagedRegister SavedLocalReferenceCookieRegister() const override;
-  ManagedRegister ReturnScratchRegister() const override;
+  ArrayRef<const ManagedRegister> CalleeSaveScratchRegisters() const override;
   uint32_t CoreSpillMask() const override;
   uint32_t FpSpillMask() const override;
   bool IsCurrentParamInRegister() override;

--- a/compiler/jni/quick/x86_64/calling_convention_x86_64.cc
+++ b/compiler/jni/quick/x86_64/calling_convention_x86_64.cc
@@ -91,15 +91,12 @@ static constexpr uint32_t kNativeFpCalleeSpillMask =
 
 // Calling convention
 
-ManagedRegister X86_64JniCallingConvention::SavedLocalReferenceCookieRegister() const {
-  // The RBX is callee-save register in both managed and native ABIs.
-  // It is saved in the stack frame and it has no special purpose like `tr` on arm/arm64.
-  static_assert((kCoreCalleeSpillMask & (1u << RBX)) != 0u);  // Managed callee save register.
-  return X86_64ManagedRegister::FromCpuRegister(RBX);
-}
-
-ManagedRegister X86_64JniCallingConvention::ReturnScratchRegister() const {
-  return ManagedRegister::NoRegister();  // No free regs, so assembler uses push/pop
+ArrayRef<const ManagedRegister> X86_64JniCallingConvention::CalleeSaveScratchRegisters() const {
+  DCHECK(!IsCriticalNative());
+  // All native callee-save registers are available.
+  static_assert((kNativeCoreCalleeSpillMask & ~kCoreCalleeSpillMask) == 0u);
+  static_assert(kNativeFpCalleeSpillMask == 0u);
+  return ArrayRef<const ManagedRegister>(kNativeCalleeSaveRegisters);
 }
 
 static ManagedRegister ReturnRegisterForShorty(const char* shorty, bool jni ATTRIBUTE_UNUSED) {

--- a/compiler/jni/quick/x86_64/calling_convention_x86_64.h
+++ b/compiler/jni/quick/x86_64/calling_convention_x86_64.h
@@ -58,8 +58,7 @@ class X86_64JniCallingConvention final : public JniCallingConvention {
   size_t FrameSize() const override;
   size_t OutFrameSize() const override;
   ArrayRef<const ManagedRegister> CalleeSaveRegisters() const override;
-  ManagedRegister SavedLocalReferenceCookieRegister() const override;
-  ManagedRegister ReturnScratchRegister() const override;
+  ArrayRef<const ManagedRegister> CalleeSaveScratchRegisters() const override;
   uint32_t CoreSpillMask() const override;
   uint32_t FpSpillMask() const override;
   bool IsCurrentParamInRegister() override;

--- a/compiler/optimizing/code_generator_arm64.cc
+++ b/compiler/optimizing/code_generator_arm64.cc
@@ -1902,8 +1902,22 @@ void CodeGeneratorARM64::GenerateMemoryBarrier(MemBarrierKind kind) {
   __ Dmb(InnerShareable, type);
 }
 
+bool CodeGeneratorARM64::CanUseImplicitSuspendCheck() const {
+  // Use implicit suspend checks if requested in compiler options unless there are SIMD
+  // instructions in the graph. The implicit suspend check saves all FP registers as
+  // 64-bit (in line with the calling convention) but SIMD instructions can use 128-bit
+  // registers, so they need to be saved in an explicit slow path.
+  return GetCompilerOptions().GetImplicitSuspendChecks() && !GetGraph()->HasSIMD();
+}
+
 void InstructionCodeGeneratorARM64::GenerateSuspendCheck(HSuspendCheck* instruction,
                                                          HBasicBlock* successor) {
+  if (codegen_->CanUseImplicitSuspendCheck()) {
+    __ Ldr(kImplicitSuspendCheckRegister, MemOperand(kImplicitSuspendCheckRegister));
+    codegen_->RecordPcInfo(instruction, instruction->GetDexPc());
+    return;
+  }
+
   SuspendCheckSlowPathARM64* slow_path =
       down_cast<SuspendCheckSlowPathARM64*>(instruction->GetSlowPath());
   if (slow_path == nullptr) {
@@ -3496,7 +3510,9 @@ void InstructionCodeGeneratorARM64::HandleGoto(HInstruction* got, HBasicBlock* s
   if (info != nullptr && info->IsBackEdge(*block) && info->HasSuspendCheck()) {
     codegen_->MaybeIncrementHotness(/* is_frame_entry= */ false);
     GenerateSuspendCheck(info->GetSuspendCheck(), successor);
-    return;
+    if (!codegen_->CanUseImplicitSuspendCheck()) {
+      return;  // `GenerateSuspendCheck()` emitted the jump.
+    }
   }
   if (block->IsEntryBlock() && (previous != nullptr) && previous->IsSuspendCheck()) {
     GenerateSuspendCheck(previous->AsSuspendCheck(), nullptr);

--- a/compiler/optimizing/code_generator_arm64.h
+++ b/compiler/optimizing/code_generator_arm64.h
@@ -80,6 +80,8 @@ static constexpr size_t kParameterFPRegistersLength = arraysize(kParameterFPRegi
 const vixl::aarch64::Register tr = vixl::aarch64::x19;
 // Marking Register.
 const vixl::aarch64::Register mr = vixl::aarch64::x20;
+// Implicit suspend check register.
+const vixl::aarch64::Register kImplicitSuspendCheckRegister = vixl::aarch64::x21;
 // Method register on invoke.
 static const vixl::aarch64::Register kArtMethodRegister = vixl::aarch64::x0;
 const vixl::aarch64::CPURegList vixl_reserved_core_registers(vixl::aarch64::ip0,
@@ -91,6 +93,7 @@ const vixl::aarch64::CPURegList runtime_reserved_core_registers =
         tr,
         // Reserve X20 as Marking Register when emitting Baker read barriers.
         ((kEmitCompilerReadBarrier && kUseBakerReadBarrier) ? mr : vixl::aarch64::NoCPUReg),
+        kImplicitSuspendCheckRegister,
         vixl::aarch64::lr);
 
 // Some instructions have special requirements for a temporary, for example
@@ -961,6 +964,8 @@ class CodeGeneratorARM64 : public CodeGenerator {
 
   void MaybeGenerateInlineCacheCheck(HInstruction* instruction, vixl::aarch64::Register klass);
   void MaybeIncrementHotness(bool is_frame_entry);
+
+  bool CanUseImplicitSuspendCheck() const;
 
  private:
   // Encoding of thunk type and data for link-time generated thunks for Baker read barriers.

--- a/compiler/optimizing/intrinsics_arm_vixl.cc
+++ b/compiler/optimizing/intrinsics_arm_vixl.cc
@@ -4786,14 +4786,16 @@ static void GenerateVarHandleCompareAndSetOrExchange(HInvoke* invoke,
         seq_cst_barrier ? MemBarrierKind::kAnyAny : MemBarrierKind::kLoadAny);
   }
 
+  if (byte_swap && value_type == DataType::Type::kInt64) {
+    // Undo byte swapping in `expected` and `new_value`. We do not have the
+    // information whether the value in these registers shall be needed later.
+    GenerateReverseBytesInPlaceForEachWord(assembler, expected);
+    GenerateReverseBytesInPlaceForEachWord(assembler, new_value);
+  }
   if (!return_success) {
     if (byte_swap) {
       if (value_type == DataType::Type::kInt64) {
         GenerateReverseBytesInPlaceForEachWord(assembler, old_value);
-        // Undo byte swapping in `expected` and `new_value`. We do not have the
-        // information whether the value in these registers shall be needed later.
-        GenerateReverseBytesInPlaceForEachWord(assembler, expected);
-        GenerateReverseBytesInPlaceForEachWord(assembler, new_value);
       } else {
         GenerateReverseBytes(assembler, value_type, old_value, out);
       }

--- a/compiler/optimizing/optimizing_compiler.cc
+++ b/compiler/optimizing/optimizing_compiler.cc
@@ -1228,11 +1228,6 @@ bool OptimizingCompiler::JitCompile(Thread* self,
                                     CompilationKind compilation_kind,
                                     jit::JitLogger* jit_logger) {
   const CompilerOptions& compiler_options = GetCompilerOptions();
-  // If the baseline flag was explicitly passed, change the compilation kind
-  // from optimized to baseline.
-  if (compiler_options.IsBaseline() && compilation_kind == CompilationKind::kOptimized) {
-    compilation_kind = CompilationKind::kBaseline;
-  }
   DCHECK(compiler_options.IsJitCompiler());
   DCHECK_EQ(compiler_options.IsJitCompilerForSharedCode(), code_cache->IsSharedRegion(*region));
   StackHandleScope<3> hs(self);

--- a/compiler/optimizing/stack_map_test.cc
+++ b/compiler/optimizing/stack_map_test.cc
@@ -470,11 +470,9 @@ TEST(StackMapTest, TestNoDexRegisterMap) {
   stream.BeginMethod(32, 0, 0, 1);
 
   ArenaBitVector sp_mask(&allocator, 0, false);
-  uint32_t number_of_dex_registers = 0;
   stream.BeginStackMapEntry(0, 64 * kPcAlign, 0x3, &sp_mask);
   stream.EndStackMapEntry();
 
-  number_of_dex_registers = 1;
   stream.BeginStackMapEntry(1, 68 * kPcAlign, 0x4, &sp_mask);
   stream.AddDexRegisterEntry(Kind::kNone, 0);
   stream.EndStackMapEntry();

--- a/compiler/utils/arm/jni_macro_assembler_arm_vixl.h
+++ b/compiler/utils/arm/jni_macro_assembler_arm_vixl.h
@@ -61,8 +61,11 @@ class ArmVIXLJNIMacroAssembler final
   void IncreaseFrameSize(size_t adjust) override;
   void DecreaseFrameSize(size_t adjust) override;
 
+  ManagedRegister CoreRegisterWithSize(ManagedRegister src, size_t size) override;
+
   // Store routines.
   void Store(FrameOffset offs, ManagedRegister src, size_t size) override;
+  void Store(ManagedRegister base, MemberOffset offs, ManagedRegister src, size_t size) override;
   void StoreRef(FrameOffset dest, ManagedRegister src) override;
   void StoreRawPtr(FrameOffset dest, ManagedRegister src) override;
 
@@ -76,6 +79,7 @@ class ArmVIXLJNIMacroAssembler final
 
   // Load routines.
   void Load(ManagedRegister dest, FrameOffset src, size_t size) override;
+  void Load(ManagedRegister dest, ManagedRegister base, MemberOffset offs, size_t size) override;
 
   void LoadFromThread(ManagedRegister dest,
                       ThreadOffset32 src,

--- a/compiler/utils/arm64/jni_macro_assembler_arm64.h
+++ b/compiler/utils/arm64/jni_macro_assembler_arm64.h
@@ -64,8 +64,11 @@ class Arm64JNIMacroAssembler final : public JNIMacroAssemblerFwd<Arm64Assembler,
   void IncreaseFrameSize(size_t adjust) override;
   void DecreaseFrameSize(size_t adjust) override;
 
+  ManagedRegister CoreRegisterWithSize(ManagedRegister src, size_t size) override;
+
   // Store routines.
   void Store(FrameOffset offs, ManagedRegister src, size_t size) override;
+  void Store(ManagedRegister base, MemberOffset offs, ManagedRegister src, size_t size) override;
   void StoreRef(FrameOffset dest, ManagedRegister src) override;
   void StoreRawPtr(FrameOffset dest, ManagedRegister src) override;
   void StoreImmediateToFrame(FrameOffset dest, uint32_t imm) override;
@@ -75,6 +78,7 @@ class Arm64JNIMacroAssembler final : public JNIMacroAssemblerFwd<Arm64Assembler,
 
   // Load routines.
   void Load(ManagedRegister dest, FrameOffset src, size_t size) override;
+  void Load(ManagedRegister dest, ManagedRegister base, MemberOffset offs, size_t size) override;
   void LoadFromThread(ManagedRegister dest, ThreadOffset64 src, size_t size) override;
   void LoadRef(ManagedRegister dest, FrameOffset src) override;
   void LoadRef(ManagedRegister dest,

--- a/compiler/utils/jni_macro_assembler.h
+++ b/compiler/utils/jni_macro_assembler.h
@@ -111,8 +111,13 @@ class JNIMacroAssembler : public DeletableArenaObject<kArenaAllocAssembler> {
   virtual void IncreaseFrameSize(size_t adjust) = 0;
   virtual void DecreaseFrameSize(size_t adjust) = 0;
 
+  // Return the same core register but with correct size if the architecture-specific
+  // ManagedRegister has different representation for different sizes.
+  virtual ManagedRegister CoreRegisterWithSize(ManagedRegister src, size_t size) = 0;
+
   // Store routines
   virtual void Store(FrameOffset offs, ManagedRegister src, size_t size) = 0;
+  virtual void Store(ManagedRegister base, MemberOffset offs, ManagedRegister src, size_t size) = 0;
   virtual void StoreRef(FrameOffset dest, ManagedRegister src) = 0;
   virtual void StoreRawPtr(FrameOffset dest, ManagedRegister src) = 0;
 
@@ -129,6 +134,7 @@ class JNIMacroAssembler : public DeletableArenaObject<kArenaAllocAssembler> {
 
   // Load routines
   virtual void Load(ManagedRegister dest, FrameOffset src, size_t size) = 0;
+  virtual void Load(ManagedRegister dest, ManagedRegister base, MemberOffset offs, size_t size) = 0;
 
   virtual void LoadFromThread(ManagedRegister dest,
                               ThreadOffset<kPointerSize> src,

--- a/compiler/utils/x86/jni_macro_assembler_x86.cc
+++ b/compiler/utils/x86/jni_macro_assembler_x86.cc
@@ -127,33 +127,48 @@ static void DecreaseFrameSizeImpl(X86Assembler* assembler, size_t adjust) {
   }
 }
 
+ManagedRegister X86JNIMacroAssembler::CoreRegisterWithSize(ManagedRegister src, size_t size) {
+  DCHECK(src.AsX86().IsCpuRegister());
+  DCHECK_EQ(size, 4u);
+  return src;
+}
+
 void X86JNIMacroAssembler::DecreaseFrameSize(size_t adjust) {
   DecreaseFrameSizeImpl(&asm_, adjust);
 }
 
 void X86JNIMacroAssembler::Store(FrameOffset offs, ManagedRegister msrc, size_t size) {
+  Store(X86ManagedRegister::FromCpuRegister(ESP), MemberOffset(offs.Int32Value()), msrc, size);
+}
+
+void X86JNIMacroAssembler::Store(ManagedRegister mbase,
+                                 MemberOffset offs,
+                                 ManagedRegister msrc,
+                                 size_t size) {
+  X86ManagedRegister base = mbase.AsX86();
   X86ManagedRegister src = msrc.AsX86();
   if (src.IsNoRegister()) {
     CHECK_EQ(0u, size);
   } else if (src.IsCpuRegister()) {
     CHECK_EQ(4u, size);
-    __ movl(Address(ESP, offs), src.AsCpuRegister());
+    __ movl(Address(base.AsCpuRegister(), offs), src.AsCpuRegister());
   } else if (src.IsRegisterPair()) {
     CHECK_EQ(8u, size);
-    __ movl(Address(ESP, offs), src.AsRegisterPairLow());
-    __ movl(Address(ESP, FrameOffset(offs.Int32Value()+4)), src.AsRegisterPairHigh());
+    __ movl(Address(base.AsCpuRegister(), offs), src.AsRegisterPairLow());
+    __ movl(Address(base.AsCpuRegister(), FrameOffset(offs.Int32Value()+4)),
+            src.AsRegisterPairHigh());
   } else if (src.IsX87Register()) {
     if (size == 4) {
-      __ fstps(Address(ESP, offs));
+      __ fstps(Address(base.AsCpuRegister(), offs));
     } else {
-      __ fstpl(Address(ESP, offs));
+      __ fstpl(Address(base.AsCpuRegister(), offs));
     }
   } else {
     CHECK(src.IsXmmRegister());
     if (size == 4) {
-      __ movss(Address(ESP, offs), src.AsXmmRegister());
+      __ movss(Address(base.AsCpuRegister(), offs), src.AsXmmRegister());
     } else {
-      __ movsd(Address(ESP, offs), src.AsXmmRegister());
+      __ movsd(Address(base.AsCpuRegister(), offs), src.AsXmmRegister());
     }
   }
 }
@@ -191,28 +206,37 @@ void X86JNIMacroAssembler::StoreSpanning(FrameOffset /*dst*/,
 }
 
 void X86JNIMacroAssembler::Load(ManagedRegister mdest, FrameOffset src, size_t size) {
+  Load(mdest, X86ManagedRegister::FromCpuRegister(ESP), MemberOffset(src.Int32Value()), size);
+}
+
+void X86JNIMacroAssembler::Load(ManagedRegister mdest,
+                                ManagedRegister mbase,
+                                MemberOffset offs,
+                                size_t size) {
   X86ManagedRegister dest = mdest.AsX86();
+  X86ManagedRegister base = mbase.AsX86();
   if (dest.IsNoRegister()) {
     CHECK_EQ(0u, size);
   } else if (dest.IsCpuRegister()) {
     CHECK_EQ(4u, size);
-    __ movl(dest.AsCpuRegister(), Address(ESP, src));
+    __ movl(dest.AsCpuRegister(), Address(base.AsCpuRegister(), offs));
   } else if (dest.IsRegisterPair()) {
     CHECK_EQ(8u, size);
-    __ movl(dest.AsRegisterPairLow(), Address(ESP, src));
-    __ movl(dest.AsRegisterPairHigh(), Address(ESP, FrameOffset(src.Int32Value()+4)));
+    __ movl(dest.AsRegisterPairLow(), Address(base.AsCpuRegister(), offs));
+    __ movl(dest.AsRegisterPairHigh(),
+            Address(base.AsCpuRegister(), FrameOffset(offs.Int32Value()+4)));
   } else if (dest.IsX87Register()) {
     if (size == 4) {
-      __ flds(Address(ESP, src));
+      __ flds(Address(base.AsCpuRegister(), offs));
     } else {
-      __ fldl(Address(ESP, src));
+      __ fldl(Address(base.AsCpuRegister(), offs));
     }
   } else {
     CHECK(dest.IsXmmRegister());
     if (size == 4) {
-      __ movss(dest.AsXmmRegister(), Address(ESP, src));
+      __ movss(dest.AsXmmRegister(), Address(base.AsCpuRegister(), offs));
     } else {
-      __ movsd(dest.AsXmmRegister(), Address(ESP, src));
+      __ movsd(dest.AsXmmRegister(), Address(base.AsCpuRegister(), offs));
     }
   }
 }

--- a/compiler/utils/x86/jni_macro_assembler_x86.h
+++ b/compiler/utils/x86/jni_macro_assembler_x86.h
@@ -54,8 +54,11 @@ class X86JNIMacroAssembler final : public JNIMacroAssemblerFwd<X86Assembler, Poi
   void IncreaseFrameSize(size_t adjust) override;
   void DecreaseFrameSize(size_t adjust) override;
 
+  ManagedRegister CoreRegisterWithSize(ManagedRegister src, size_t size) override;
+
   // Store routines
   void Store(FrameOffset offs, ManagedRegister src, size_t size) override;
+  void Store(ManagedRegister base, MemberOffset offs, ManagedRegister src, size_t size) override;
   void StoreRef(FrameOffset dest, ManagedRegister src) override;
   void StoreRawPtr(FrameOffset dest, ManagedRegister src) override;
 
@@ -69,6 +72,7 @@ class X86JNIMacroAssembler final : public JNIMacroAssemblerFwd<X86Assembler, Poi
 
   // Load routines
   void Load(ManagedRegister dest, FrameOffset src, size_t size) override;
+  void Load(ManagedRegister dest, ManagedRegister base, MemberOffset offs, size_t size) override;
 
   void LoadFromThread(ManagedRegister dest, ThreadOffset32 src, size_t size) override;
 

--- a/compiler/utils/x86_64/jni_macro_assembler_x86_64.h
+++ b/compiler/utils/x86_64/jni_macro_assembler_x86_64.h
@@ -55,8 +55,11 @@ class X86_64JNIMacroAssembler final : public JNIMacroAssemblerFwd<X86_64Assemble
   void IncreaseFrameSize(size_t adjust) override;
   void DecreaseFrameSize(size_t adjust) override;
 
+  ManagedRegister CoreRegisterWithSize(ManagedRegister src, size_t size) override;
+
   // Store routines
   void Store(FrameOffset offs, ManagedRegister src, size_t size) override;
+  void Store(ManagedRegister base, MemberOffset offs, ManagedRegister src, size_t size) override;
   void StoreRef(FrameOffset dest, ManagedRegister src) override;
   void StoreRawPtr(FrameOffset dest, ManagedRegister src) override;
 
@@ -70,6 +73,7 @@ class X86_64JNIMacroAssembler final : public JNIMacroAssemblerFwd<X86_64Assemble
 
   // Load routines
   void Load(ManagedRegister dest, FrameOffset src, size_t size) override;
+  void Load(ManagedRegister dest, ManagedRegister base, MemberOffset offs, size_t size) override;
 
   void LoadFromThread(ManagedRegister dest, ThreadOffset64 src, size_t size) override;
 

--- a/dex2oat/dex2oat.cc
+++ b/dex2oat/dex2oat.cc
@@ -826,9 +826,11 @@ class Dex2Oat final {
     // Checks are all explicit until we know the architecture.
     // Set the compilation target's implicit checks options.
     switch (compiler_options_->GetInstructionSet()) {
+      case InstructionSet::kArm64:
+        compiler_options_->implicit_suspend_checks_ = true;
+        FALLTHROUGH_INTENDED;
       case InstructionSet::kArm:
       case InstructionSet::kThumb2:
-      case InstructionSet::kArm64:
       case InstructionSet::kX86:
       case InstructionSet::kX86_64:
         compiler_options_->implicit_null_checks_ = true;

--- a/libartbase/base/systrace.h
+++ b/libartbase/base/systrace.h
@@ -27,24 +27,37 @@
 namespace art {
 
 inline bool ATraceEnabled() {
+#ifdef NDEBUG
+  return false;
+#else
   bool enabled = false;
   if (UNLIKELY(PaletteTraceEnabled(&enabled) == PALETTE_STATUS_OK && enabled)) {
     return true;
   } else {
     return false;
   }
+#endif
 }
 
 inline void ATraceBegin(const char* name) {
+  (void)name;
+#ifndef NDEBUG
   PaletteTraceBegin(name);
+#endif
 }
 
 inline void ATraceEnd() {
+#ifndef NDEBUG
   PaletteTraceEnd();
+#endif
 }
 
 inline void ATraceIntegerValue(const char* name, int32_t value) {
+  (void)name;
+  (void)value;
+#ifndef NDEBUG
   PaletteTraceIntegerValue(name, value);
+#endif
 }
 
 class ScopedTrace {

--- a/libprofile/profile/profile_compilation_info.cc
+++ b/libprofile/profile/profile_compilation_info.cc
@@ -2622,6 +2622,10 @@ void ProfileCompilationInfo::DexFileData::WriteMethods(SafeBuffer& buffer) const
     }
   });
   DCHECK_EQ(saved_bitmap_index * num_method_ids, saved_bitmap_bit_size);
+  // Clear the padding bits.
+  size_t padding_bit_size = saved_bitmap_byte_size * kBitsPerByte - saved_bitmap_bit_size;
+  BitMemoryRegion padding_region(buffer.GetCurrentPtr(), saved_bitmap_bit_size, padding_bit_size);
+  padding_region.StoreBits(/*bit_offset=*/ 0u, /*value=*/ 0u, /*bit_length=*/ padding_bit_size);
   buffer.Advance(saved_bitmap_byte_size);
 
   uint16_t last_method_index = 0;

--- a/openjdkjvmti/events.cc
+++ b/openjdkjvmti/events.cc
@@ -624,10 +624,7 @@ class JvmtiMethodTraceListener final : public art::instrumentation::Instrumentat
   }
 
   // Call-back for when a method is entered.
-  void MethodEntered(art::Thread* self,
-                     art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,
-                     art::ArtMethod* method,
-                     uint32_t dex_pc ATTRIBUTE_UNUSED)
+  void MethodEntered(art::Thread* self, art::ArtMethod* method)
       REQUIRES_SHARED(art::Locks::mutator_lock_) override {
     if (!method->IsRuntimeMethod() &&
         event_handler_->IsEventEnabledAnywhere(ArtJvmtiEvent::kMethodEntry)) {

--- a/openjdkjvmti/events.cc
+++ b/openjdkjvmti/events.cc
@@ -639,9 +639,7 @@ class JvmtiMethodTraceListener final : public art::instrumentation::Instrumentat
   // TODO Maybe try to combine this with below using templates?
   // Callback for when a method is exited with a reference return value.
   void MethodExited(art::Thread* self,
-                    art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,
                     art::ArtMethod* method,
-                    uint32_t dex_pc ATTRIBUTE_UNUSED,
                     art::instrumentation::OptionalFrame frame,
                     art::MutableHandle<art::mirror::Object>& return_value)
       REQUIRES_SHARED(art::Locks::mutator_lock_) override {
@@ -694,9 +692,7 @@ class JvmtiMethodTraceListener final : public art::instrumentation::Instrumentat
 
   // Call-back for when a method is exited.
   void MethodExited(art::Thread* self,
-                    art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,
                     art::ArtMethod* method,
-                    uint32_t dex_pc ATTRIBUTE_UNUSED,
                     art::instrumentation::OptionalFrame frame,
                     art::JValue& return_value) REQUIRES_SHARED(art::Locks::mutator_lock_) override {
     if (frame.has_value() &&

--- a/runtime/arch/arm/jni_frame_arm.h
+++ b/runtime/arch/arm/jni_frame_arm.h
@@ -30,7 +30,7 @@ namespace arm {
 constexpr size_t kFramePointerSize = static_cast<size_t>(PointerSize::k32);
 static_assert(kArmPointerSize == PointerSize::k32, "Unexpected ARM pointer size");
 
-// The AAPCS requires 8-byte alignement. This is not as strict as the Managed ABI stack alignment.
+// The AAPCS requires 8-byte alignment. This is not as strict as the Managed ABI stack alignment.
 static constexpr size_t kAapcsStackAlignment = 8u;
 static_assert(kAapcsStackAlignment < kStackAlignment);
 

--- a/runtime/arch/arm64/asm_support_arm64.S
+++ b/runtime/arch/arm64/asm_support_arm64.S
@@ -41,6 +41,9 @@
 #define wMR w20
 #endif
 
+// Implicit suspend check register.
+#define xSUSPEND x21
+
 .macro CFI_EXPRESSION_BREG n, b, offset
     .if (-0x40 <= (\offset)) && ((\offset) < 0x40)
         CFI_EXPRESSION_BREG_1(\n, \b, \offset)
@@ -172,6 +175,19 @@
 #if defined(USE_READ_BARRIER) && defined(USE_BAKER_READ_BARRIER)
     ldr wMR, [xSELF, #THREAD_IS_GC_MARKING_OFFSET]
 #endif
+.endm
+
+// Macro to refresh the suspend check register.
+//
+// We do not refresh `xSUSPEND` after every transition to Runnable, so there is
+// a chance that an implicit suspend check loads null to xSUSPEND but before
+// causing a SIGSEGV at the next implicit suspend check we make a runtime call
+// that performs the suspend check explicitly. This can cause a spurious fault
+// without a pending suspend check request but it should be rare and the fault
+// overhead was already expected when we triggered the suspend check, we just
+// pay the price later than expected.
+.macro REFRESH_SUSPEND_CHECK_REGISTER
+    ldr xSUSPEND, [xSELF, #THREAD_SUSPEND_TRIGGER_OFFSET]
 .endm
 
     /*

--- a/runtime/arch/arm64/fault_handler_arm64.cc
+++ b/runtime/arch/arm64/fault_handler_arm64.cc
@@ -95,64 +95,40 @@ bool NullPointerHandler::Action(int sig ATTRIBUTE_UNUSED, siginfo_t* info, void*
   return true;
 }
 
-// A suspend check is done using the following instruction sequence:
-//      0xf7223228: f9405640  ldr x0, [x18, #168]
-// .. some intervening instructions
-//      0xf7223230: f9400000  ldr x0, [x0]
-
-// The offset from r18 is Thread::ThreadSuspendTriggerOffset().
-// To check for a suspend check, we examine the instructions that caused
-// the fault (at PC-4 and PC).
+// A suspend check is done using the following instruction:
+//      0x...: f94002b5  ldr x21, [x21, #0]
+// To check for a suspend check, we examine the instruction that caused the fault (at PC).
 bool SuspensionHandler::Action(int sig ATTRIBUTE_UNUSED, siginfo_t* info ATTRIBUTE_UNUSED,
                                void* context) {
-  // These are the instructions to check for.  The first one is the ldr x0,[r18,#xxx]
-  // where xxx is the offset of the suspend trigger.
-  uint32_t checkinst1 = 0xf9400240 |
-      (Thread::ThreadSuspendTriggerOffset<PointerSize::k64>().Int32Value() << 7);
-  uint32_t checkinst2 = 0xf9400000;
+  constexpr uint32_t kSuspendCheckRegister = 21;
+  constexpr uint32_t checkinst =
+      0xf9400000 | (kSuspendCheckRegister << 5) | (kSuspendCheckRegister << 0);
 
   struct ucontext *uc = reinterpret_cast<struct ucontext *>(context);
   struct sigcontext *sc = reinterpret_cast<struct sigcontext*>(&uc->uc_mcontext);
-  uint8_t* ptr2 = reinterpret_cast<uint8_t*>(sc->pc);
-  uint8_t* ptr1 = ptr2 - 4;
   VLOG(signals) << "checking suspend";
 
-  uint32_t inst2 = *reinterpret_cast<uint32_t*>(ptr2);
-  VLOG(signals) << "inst2: " << std::hex << inst2 << " checkinst2: " << checkinst2;
-  if (inst2 != checkinst2) {
-    // Second instruction is not good, not ours.
+  uint32_t inst = *reinterpret_cast<uint32_t*>(sc->pc);
+  VLOG(signals) << "inst: " << std::hex << inst << " checkinst: " << checkinst;
+  if (inst != checkinst) {
+    // The instruction is not good, not ours.
     return false;
   }
 
-  // The first instruction can a little bit up the stream due to load hoisting
-  // in the compiler.
-  uint8_t* limit = ptr1 - 80;   // Compiler will hoist to a max of 20 instructions.
-  bool found = false;
-  while (ptr1 > limit) {
-    uint32_t inst1 = *reinterpret_cast<uint32_t*>(ptr1);
-    VLOG(signals) << "inst1: " << std::hex << inst1 << " checkinst1: " << checkinst1;
-    if (inst1 == checkinst1) {
-      found = true;
-      break;
-    }
-    ptr1 -= 4;
-  }
-  if (found) {
-    VLOG(signals) << "suspend check match";
-    // This is a suspend check.  Arrange for the signal handler to return to
-    // art_quick_implicit_suspend.  Also set LR so that after the suspend check it
-    // will resume the instruction (current PC + 4).  PC points to the
-    // ldr x0,[x0,#0] instruction (r0 will be 0, set by the trigger).
+  // This is a suspend check.
+  VLOG(signals) << "suspend check match";
 
-    sc->regs[30] = sc->pc + 4;
-    sc->pc = reinterpret_cast<uintptr_t>(art_quick_implicit_suspend);
+  // Set LR so that after the suspend check it will resume after the
+  // `ldr x21, [x21,#0]` instruction that triggered the suspend check.
+  sc->regs[30] = sc->pc + 4;
+  // Arrange for the signal handler to return to `art_quick_implicit_suspend()`.
+  sc->pc = reinterpret_cast<uintptr_t>(art_quick_implicit_suspend);
 
-    // Now remove the suspend trigger that caused this fault.
-    Thread::Current()->RemoveSuspendTrigger();
-    VLOG(signals) << "removed suspend trigger invoking test suspend";
-    return true;
-  }
-  return false;
+  // Now remove the suspend trigger that caused this fault.
+  Thread::Current()->RemoveSuspendTrigger();
+  VLOG(signals) << "removed suspend trigger invoking test suspend";
+
+  return true;
 }
 
 bool StackOverflowHandler::Action(int sig ATTRIBUTE_UNUSED, siginfo_t* info ATTRIBUTE_UNUSED,

--- a/runtime/arch/arm64/jni_frame_arm64.h
+++ b/runtime/arch/arm64/jni_frame_arm64.h
@@ -30,7 +30,7 @@ namespace arm64 {
 constexpr size_t kFramePointerSize = static_cast<size_t>(PointerSize::k64);
 static_assert(kArm64PointerSize == PointerSize::k64, "Unexpected ARM64 pointer size");
 
-// The AAPCS64 requires 16-byte alignement. This is the same as the Managed ABI stack alignment.
+// The AAPCS64 requires 16-byte alignment. This is the same as the Managed ABI stack alignment.
 static constexpr size_t kAapcs64StackAlignment = 16u;
 static_assert(kAapcs64StackAlignment == kStackAlignment);
 

--- a/runtime/arch/arm64/quick_entrypoints_arm64.S
+++ b/runtime/arch/arm64/quick_entrypoints_arm64.S
@@ -361,10 +361,11 @@ INVOKE_TRAMPOLINE art_quick_invoke_virtual_trampoline_with_access_check, artInvo
 
 
 .macro INVOKE_STUB_CREATE_FRAME
-SAVE_SIZE=6*8   // x4, x5, x19, x20, FP, LR saved.
+SAVE_SIZE=8*8   // x4, x5, <padding>, x19, x20, x21, FP, LR saved.
     SAVE_TWO_REGS_INCREASE_FRAME x4, x5, SAVE_SIZE
-    SAVE_TWO_REGS x19, x20, 16
-    SAVE_TWO_REGS xFP, xLR, 32
+    SAVE_REG      x19,      24
+    SAVE_TWO_REGS x20, x21, 32
+    SAVE_TWO_REGS xFP, xLR, 48
 
     mov xFP, sp                            // Use xFP for frame pointer, as it's callee-saved.
     .cfi_def_cfa_register xFP
@@ -401,6 +402,7 @@ SAVE_SIZE=6*8   // x4, x5, x19, x20, FP, LR saved.
 .macro INVOKE_STUB_CALL_AND_RETURN
 
     REFRESH_MARKING_REGISTER
+    REFRESH_SUSPEND_CHECK_REGISTER
 
     // load method-> METHOD_QUICK_CODE_OFFSET
     ldr x9, [x0, #ART_METHOD_QUICK_CODE_OFFSET_64]
@@ -412,8 +414,9 @@ SAVE_SIZE=6*8   // x4, x5, x19, x20, FP, LR saved.
     .cfi_def_cfa_register sp
 
     // Restore saved registers including value address and shorty address.
-    RESTORE_TWO_REGS x19, x20, 16
-    RESTORE_TWO_REGS xFP, xLR, 32
+    RESTORE_REG      x19,      24
+    RESTORE_TWO_REGS x20, x21, 32
+    RESTORE_TWO_REGS xFP, xLR, 48
     RESTORE_TWO_REGS_DECREASE_FRAME x4, x5, SAVE_SIZE
 
     // Store result (w0/x0/s0/d0) appropriately, depending on resultType.
@@ -765,6 +768,7 @@ ENTRY art_quick_osr_stub
 
     mov xSELF, x5                         // Move thread pointer into SELF register.
     REFRESH_MARKING_REGISTER
+    REFRESH_SUSPEND_CHECK_REGISTER
 
     INCREASE_FRAME 16
     str xzr, [sp]                         // Store null for ArtMethod* slot
@@ -877,6 +881,7 @@ ENTRY art_quick_do_long_jump
     mov sp, xIP0
 
     REFRESH_MARKING_REGISTER
+    REFRESH_SUSPEND_CHECK_REGISTER
 
     br  xIP1
 END art_quick_do_long_jump
@@ -1659,21 +1664,29 @@ GENERATE_ALLOC_ARRAY_TLAB art_quick_alloc_array_resolved64_tlab, artAllocArrayFr
      */
     .extern artTestSuspendFromCode
 ENTRY art_quick_test_suspend
-    SETUP_SAVE_EVERYTHING_FRAME RUNTIME_SAVE_EVERYTHING_FOR_SUSPEND_CHECK_METHOD_OFFSET  // save callee saves for stack crawl
+                                        // Save callee saves for stack crawl.
+    SETUP_SAVE_EVERYTHING_FRAME RUNTIME_SAVE_EVERYTHING_FOR_SUSPEND_CHECK_METHOD_OFFSET
     mov    x0, xSELF
-    bl     artTestSuspendFromCode             // (Thread*)
+    bl     artTestSuspendFromCode       // (Thread*)
     RESTORE_SAVE_EVERYTHING_FRAME
     REFRESH_MARKING_REGISTER
+    REFRESH_SUSPEND_CHECK_REGISTER
     ret
 END art_quick_test_suspend
 
+    /*
+     * Redirection point from implicit suspend check fault handler.
+     */
+    .extern artTestSuspendFromCode
 ENTRY art_quick_implicit_suspend
+                                        // Save callee saves for stack crawl.
+    SETUP_SAVE_EVERYTHING_FRAME RUNTIME_SAVE_EVERYTHING_FOR_SUSPEND_CHECK_METHOD_OFFSET
     mov    x0, xSELF
-    SETUP_SAVE_REFS_ONLY_FRAME                // save callee saves for stack crawl
-    bl     artTestSuspendFromCode             // (Thread*)
-    RESTORE_SAVE_REFS_ONLY_FRAME
+    bl     artTestSuspendFromCode       // (Thread*)
+    RESTORE_SAVE_EVERYTHING_FRAME
     REFRESH_MARKING_REGISTER
-    ret
+    REFRESH_SUSPEND_CHECK_REGISTER
+    br     lr  // Do not use RET as we do not enter the entrypoint with "BL".
 END art_quick_implicit_suspend
 
      /*

--- a/runtime/class_linker_test.cc
+++ b/runtime/class_linker_test.cc
@@ -149,21 +149,11 @@ class ClassLinkerTest : public CommonRuntimeTest {
     EXPECT_FALSE(JavaLangObject->IsSynthetic());
     EXPECT_EQ(4U, JavaLangObject->NumDirectMethods());
     EXPECT_EQ(11U, JavaLangObject->NumVirtualMethods());
-    if (!kUseBrooksReadBarrier) {
-      EXPECT_EQ(2U, JavaLangObject->NumInstanceFields());
-    } else {
-      EXPECT_EQ(4U, JavaLangObject->NumInstanceFields());
-    }
+    EXPECT_EQ(2U, JavaLangObject->NumInstanceFields());
     EXPECT_STREQ(JavaLangObject->GetInstanceField(0)->GetName(),
                  "shadow$_klass_");
     EXPECT_STREQ(JavaLangObject->GetInstanceField(1)->GetName(),
                  "shadow$_monitor_");
-    if (kUseBrooksReadBarrier) {
-      EXPECT_STREQ(JavaLangObject->GetInstanceField(2)->GetName(),
-                   "shadow$_x_rb_ptr_");
-      EXPECT_STREQ(JavaLangObject->GetInstanceField(3)->GetName(),
-                   "shadow$_x_xpadding_");
-    }
 
     EXPECT_EQ(0U, JavaLangObject->NumStaticFields());
     EXPECT_EQ(0U, JavaLangObject->NumDirectInterfaces());
@@ -571,10 +561,6 @@ struct ObjectOffsets : public CheckOffsets<mirror::Object> {
   ObjectOffsets() : CheckOffsets<mirror::Object>(false, "Ljava/lang/Object;") {
     addOffset(OFFSETOF_MEMBER(mirror::Object, klass_), "shadow$_klass_");
     addOffset(OFFSETOF_MEMBER(mirror::Object, monitor_), "shadow$_monitor_");
-#ifdef USE_BROOKS_READ_BARRIER
-    addOffset(OFFSETOF_MEMBER(mirror::Object, x_rb_ptr_), "shadow$_x_rb_ptr_");
-    addOffset(OFFSETOF_MEMBER(mirror::Object, x_xpadding_), "shadow$_x_xpadding_");
-#endif
   }
 };
 

--- a/runtime/entrypoints/quick/quick_entrypoints.h
+++ b/runtime/entrypoints/quick/quick_entrypoints.h
@@ -54,50 +54,38 @@ struct PACKED(4) QuickEntryPoints {
 
 // JNI entrypoints.
 // TODO: NO_THREAD_SAFETY_ANALYSIS due to different control paths depending on fast JNI.
-extern uint32_t JniMethodStart(Thread* self) NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern uint32_t JniMethodFastStart(Thread* self) NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern uint32_t JniMethodStartSynchronized(jobject to_lock, Thread* self)
+extern void JniMethodStart(Thread* self) NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
+extern void JniMethodFastStart(Thread* self) NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
+extern void JniMethodStartSynchronized(jobject to_lock, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern void JniMethodEnd(uint32_t saved_local_ref_cookie, Thread* self)
+extern void JniMethodEnd(Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern void JniMethodFastEnd(uint32_t saved_local_ref_cookie, Thread* self)
+extern void JniMethodFastEnd(Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern void JniMethodEndSynchronized(uint32_t saved_local_ref_cookie, jobject locked,
-                                     Thread* self)
+extern void JniMethodEndSynchronized(jobject locked, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern mirror::Object* JniMethodEndWithReference(jobject result, uint32_t saved_local_ref_cookie,
-                                                 Thread* self)
+extern mirror::Object* JniMethodEndWithReference(jobject result, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern mirror::Object* JniMethodFastEndWithReference(jobject result,
-                                                     uint32_t saved_local_ref_cookie,
-                                                     Thread* self)
+extern mirror::Object* JniMethodFastEndWithReference(jobject result, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-
-
 extern mirror::Object* JniMethodEndWithReferenceSynchronized(jobject result,
-                                                             uint32_t saved_local_ref_cookie,
-                                                             jobject locked, Thread* self)
+                                                             jobject locked,
+                                                             Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
 
 // JNI entrypoints when monitoring entry/exit.
-extern uint32_t JniMonitoredMethodStart(Thread* self) NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern uint32_t JniMonitoredMethodStartSynchronized(jobject to_lock, Thread* self)
+extern void JniMonitoredMethodStart(Thread* self) NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
+extern void JniMonitoredMethodStartSynchronized(jobject to_lock, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern void JniMonitoredMethodEnd(uint32_t saved_local_ref_cookie, Thread* self)
+extern void JniMonitoredMethodEnd(Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern void JniMonitoredMethodEndSynchronized(uint32_t saved_local_ref_cookie,
-                                              jobject locked,
-                                              Thread* self)
+extern void JniMonitoredMethodEndSynchronized(jobject locked, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-extern mirror::Object* JniMonitoredMethodEndWithReference(jobject result,
-                                                          uint32_t saved_local_ref_cookie,
-                                                          Thread* self)
+extern mirror::Object* JniMonitoredMethodEndWithReference(jobject result, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
-
-extern mirror::Object* JniMonitoredMethodEndWithReferenceSynchronized(
-    jobject result,
-    uint32_t saved_local_ref_cookie,
-    jobject locked, Thread* self)
+extern mirror::Object* JniMonitoredMethodEndWithReferenceSynchronized(jobject result,
+                                                                      jobject locked,
+                                                                      Thread* self)
     NO_THREAD_SAFETY_ANALYSIS HOT_ATTR;
 
 

--- a/runtime/entrypoints/quick/quick_entrypoints_list.h
+++ b/runtime/entrypoints/quick/quick_entrypoints_list.h
@@ -72,15 +72,15 @@
 \
   V(AputObject, void, mirror::Array*, int32_t, mirror::Object*) \
 \
-  V(JniMethodStart, uint32_t, Thread*) \
-  V(JniMethodFastStart, uint32_t, Thread*) \
-  V(JniMethodStartSynchronized, uint32_t, jobject, Thread*) \
-  V(JniMethodEnd, void, uint32_t, Thread*) \
-  V(JniMethodFastEnd, void, uint32_t, Thread*) \
-  V(JniMethodEndSynchronized, void, uint32_t, jobject, Thread*) \
-  V(JniMethodEndWithReference, mirror::Object*, jobject, uint32_t, Thread*) \
-  V(JniMethodFastEndWithReference, mirror::Object*, jobject, uint32_t, Thread*) \
-  V(JniMethodEndWithReferenceSynchronized, mirror::Object*, jobject, uint32_t, jobject, Thread*) \
+  V(JniMethodStart, void, Thread*) \
+  V(JniMethodFastStart, void, Thread*) \
+  V(JniMethodStartSynchronized, void, jobject, Thread*) \
+  V(JniMethodEnd, void, Thread*) \
+  V(JniMethodFastEnd, void, Thread*) \
+  V(JniMethodEndSynchronized, void, jobject, Thread*) \
+  V(JniMethodEndWithReference, mirror::Object*, jobject, Thread*) \
+  V(JniMethodFastEndWithReference, mirror::Object*, jobject, Thread*) \
+  V(JniMethodEndWithReferenceSynchronized, mirror::Object*, jobject, jobject, Thread*) \
   V(QuickGenericJniTrampoline, void, ArtMethod*) \
 \
   V(LockObject, void, mirror::Object*) \

--- a/runtime/entrypoints/quick/quick_jni_entrypoints.cc
+++ b/runtime/entrypoints/quick/quick_jni_entrypoints.cc
@@ -60,27 +60,15 @@ extern void ReadBarrierJni(mirror::CompressedReference<mirror::Class>* declaring
 }
 
 // Called on entry to fast JNI, push a new local reference table only.
-extern uint32_t JniMethodFastStart(Thread* self) {
-  JNIEnvExt* env = self->GetJniEnv();
-  DCHECK(env != nullptr);
-  uint32_t saved_local_ref_cookie = bit_cast<uint32_t>(env->GetLocalRefCookie());
-  env->SetLocalRefCookie(env->GetLocalsSegmentState());
-
+extern void JniMethodFastStart(Thread* self) {
   if (kIsDebugBuild) {
     ArtMethod* native_method = *self->GetManagedStack()->GetTopQuickFrame();
     CHECK(native_method->IsFastNative()) << native_method->PrettyMethod();
   }
-
-  return saved_local_ref_cookie;
 }
 
 // Called on entry to JNI, transition out of Runnable and release share of mutator_lock_.
-extern uint32_t JniMethodStart(Thread* self) {
-  JNIEnvExt* env = self->GetJniEnv();
-  DCHECK(env != nullptr);
-  uint32_t saved_local_ref_cookie = bit_cast<uint32_t>(env->GetLocalRefCookie());
-  env->SetLocalRefCookie(env->GetLocalsSegmentState());
-
+extern void JniMethodStart(Thread* self) {
   if (kIsDebugBuild) {
     ArtMethod* native_method = *self->GetManagedStack()->GetTopQuickFrame();
     CHECK(!native_method->IsFastNative()) << native_method->PrettyMethod();
@@ -88,12 +76,11 @@ extern uint32_t JniMethodStart(Thread* self) {
 
   // Transition out of runnable.
   self->TransitionFromRunnableToSuspended(kNative);
-  return saved_local_ref_cookie;
 }
 
-extern uint32_t JniMethodStartSynchronized(jobject to_lock, Thread* self) {
+extern void JniMethodStartSynchronized(jobject to_lock, Thread* self) {
   self->DecodeJObject(to_lock)->MonitorEnter(self);
-  return JniMethodStart(self);
+  JniMethodStart(self);
 }
 
 // TODO: NO_THREAD_SAFETY_ANALYSIS due to different control paths depending on fast JNI.
@@ -159,35 +146,27 @@ static inline void UnlockJniSynchronizedMethod(jobject locked, Thread* self)
 // TODO: These should probably be templatized or macro-ized.
 // Otherwise there's just too much repetitive boilerplate.
 
-extern void JniMethodEnd(uint32_t saved_local_ref_cookie, Thread* self) {
+extern void JniMethodEnd(Thread* self) {
   GoToRunnable(self);
-  PopLocalReferences(saved_local_ref_cookie, self);
 }
 
-extern void JniMethodFastEnd(uint32_t saved_local_ref_cookie, Thread* self) {
+extern void JniMethodFastEnd(Thread* self) {
   GoToRunnableFast(self);
-  PopLocalReferences(saved_local_ref_cookie, self);
 }
 
-extern void JniMethodEndSynchronized(uint32_t saved_local_ref_cookie,
-                                     jobject locked,
-                                     Thread* self) {
+extern void JniMethodEndSynchronized(jobject locked, Thread* self) {
   GoToRunnable(self);
   UnlockJniSynchronizedMethod(locked, self);  // Must decode before pop.
-  PopLocalReferences(saved_local_ref_cookie, self);
 }
 
 // Common result handling for EndWithReference.
-static mirror::Object* JniMethodEndWithReferenceHandleResult(jobject result,
-                                                             uint32_t saved_local_ref_cookie,
-                                                             Thread* self)
+static mirror::Object* JniMethodEndWithReferenceHandleResult(jobject result, Thread* self)
     NO_THREAD_SAFETY_ANALYSIS {
   // Must decode before pop. The 'result' may not be valid in case of an exception, though.
   ObjPtr<mirror::Object> o;
   if (!self->IsExceptionPending()) {
     o = self->DecodeJObject(result);
   }
-  PopLocalReferences(saved_local_ref_cookie, self);
   // Process result.
   if (UNLIKELY(self->GetJniEnv()->IsCheckJniEnabled())) {
     // CheckReferenceResult can resolve types.
@@ -199,27 +178,22 @@ static mirror::Object* JniMethodEndWithReferenceHandleResult(jobject result,
   return o.Ptr();
 }
 
-extern mirror::Object* JniMethodFastEndWithReference(jobject result,
-                                                     uint32_t saved_local_ref_cookie,
-                                                     Thread* self) {
+extern mirror::Object* JniMethodFastEndWithReference(jobject result, Thread* self) {
   GoToRunnableFast(self);
-  return JniMethodEndWithReferenceHandleResult(result, saved_local_ref_cookie, self);
+  return JniMethodEndWithReferenceHandleResult(result, self);
 }
 
-extern mirror::Object* JniMethodEndWithReference(jobject result,
-                                                 uint32_t saved_local_ref_cookie,
-                                                 Thread* self) {
+extern mirror::Object* JniMethodEndWithReference(jobject result, Thread* self) {
   GoToRunnable(self);
-  return JniMethodEndWithReferenceHandleResult(result, saved_local_ref_cookie, self);
+  return JniMethodEndWithReferenceHandleResult(result, self);
 }
 
 extern mirror::Object* JniMethodEndWithReferenceSynchronized(jobject result,
-                                                             uint32_t saved_local_ref_cookie,
                                                              jobject locked,
                                                              Thread* self) {
   GoToRunnable(self);
   UnlockJniSynchronizedMethod(locked, self);
-  return JniMethodEndWithReferenceHandleResult(result, saved_local_ref_cookie, self);
+  return JniMethodEndWithReferenceHandleResult(result, self);
 }
 
 extern uint64_t GenericJniMethodEnd(Thread* self,
@@ -251,8 +225,10 @@ extern uint64_t GenericJniMethodEnd(Thread* self,
   }
   char return_shorty_char = called->GetShorty()[0];
   if (return_shorty_char == 'L') {
-    return reinterpret_cast<uint64_t>(JniMethodEndWithReferenceHandleResult(
-        result.l, saved_local_ref_cookie, self));
+    uint64_t ret =
+        reinterpret_cast<uint64_t>(JniMethodEndWithReferenceHandleResult(result.l, self));
+    PopLocalReferences(saved_local_ref_cookie, self);
+    return ret;
   } else {
     if (LIKELY(!critical_native)) {
       PopLocalReferences(saved_local_ref_cookie, self);
@@ -290,44 +266,37 @@ extern uint64_t GenericJniMethodEnd(Thread* self,
   }
 }
 
-extern uint32_t JniMonitoredMethodStart(Thread* self) {
-  uint32_t result = JniMethodStart(self);
+extern void JniMonitoredMethodStart(Thread* self) {
+  JniMethodStart(self);
   MONITOR_JNI(PaletteNotifyBeginJniInvocation);
-  return result;
 }
 
-extern uint32_t JniMonitoredMethodStartSynchronized(jobject to_lock, Thread* self) {
-  uint32_t result = JniMethodStartSynchronized(to_lock, self);
+extern void JniMonitoredMethodStartSynchronized(jobject to_lock, Thread* self) {
+  JniMethodStartSynchronized(to_lock, self);
   MONITOR_JNI(PaletteNotifyBeginJniInvocation);
-  return result;
 }
 
-extern void JniMonitoredMethodEnd(uint32_t saved_local_ref_cookie, Thread* self) {
+extern void JniMonitoredMethodEnd(Thread* self) {
   MONITOR_JNI(PaletteNotifyEndJniInvocation);
-  return JniMethodEnd(saved_local_ref_cookie, self);
+  JniMethodEnd(self);
 }
 
-extern void JniMonitoredMethodEndSynchronized(uint32_t saved_local_ref_cookie,
-                                             jobject locked,
-                                             Thread* self) {
+extern void JniMonitoredMethodEndSynchronized(jobject locked, Thread* self) {
   MONITOR_JNI(PaletteNotifyEndJniInvocation);
-  return JniMethodEndSynchronized(saved_local_ref_cookie, locked, self);
+  JniMethodEndSynchronized(locked, self);
 }
 
-extern mirror::Object* JniMonitoredMethodEndWithReference(jobject result,
-                                                          uint32_t saved_local_ref_cookie,
-                                                          Thread* self) {
+extern mirror::Object* JniMonitoredMethodEndWithReference(jobject result, Thread* self) {
   MONITOR_JNI(PaletteNotifyEndJniInvocation);
-  return JniMethodEndWithReference(result, saved_local_ref_cookie, self);
+  return JniMethodEndWithReference(result, self);
 }
 
 extern mirror::Object* JniMonitoredMethodEndWithReferenceSynchronized(
     jobject result,
-    uint32_t saved_local_ref_cookie,
     jobject locked,
     Thread* self) {
   MONITOR_JNI(PaletteNotifyEndJniInvocation);
-  return JniMethodEndWithReferenceSynchronized(result, saved_local_ref_cookie, locked, self);
+  return JniMethodEndWithReferenceSynchronized(result, locked, self);
 }
 
 }  // namespace art

--- a/runtime/entrypoints/quick/quick_trampoline_entrypoints.cc
+++ b/runtime/entrypoints/quick/quick_trampoline_entrypoints.cc
@@ -855,10 +855,7 @@ extern "C" uint64_t artQuickProxyInvokeHandler(
   // that performs allocations or instrumentation events.
   instrumentation::Instrumentation* instr = Runtime::Current()->GetInstrumentation();
   if (instr->HasMethodEntryListeners()) {
-    instr->MethodEnterEvent(soa.Self(),
-                            soa.Decode<mirror::Object>(rcvr_jobj),
-                            proxy_method,
-                            0);
+    instr->MethodEnterEvent(soa.Self(), proxy_method);
     if (soa.Self()->IsExceptionPending()) {
       instr->MethodUnwindEvent(self,
                                soa.Decode<mirror::Object>(rcvr_jobj),

--- a/runtime/entrypoints/quick/quick_trampoline_entrypoints.cc
+++ b/runtime/entrypoints/quick/quick_trampoline_entrypoints.cc
@@ -2119,27 +2119,33 @@ extern "C" const void* artQuickGenericJniTrampoline(Thread* self,
     }
   }
 
-  uint32_t cookie;
-  uint32_t* sp32;
   // Skip calling JniMethodStart for @CriticalNative.
   if (LIKELY(!critical_native)) {
-    // Start JNI, save the cookie.
+    // Start JNI.
     if (called->IsSynchronized()) {
       DCHECK(normal_native) << " @FastNative and synchronize is not supported";
       jobject lock = GetGenericJniSynchronizationObject(self, called);
-      cookie = JniMethodStartSynchronized(lock, self);
+      JniMethodStartSynchronized(lock, self);
       if (self->IsExceptionPending()) {
         return nullptr;  // Report error.
       }
     } else {
       if (fast_native) {
-        cookie = JniMethodFastStart(self);
+        JniMethodFastStart(self);
       } else {
         DCHECK(normal_native);
-        cookie = JniMethodStart(self);
+        JniMethodStart(self);
       }
     }
-    sp32 = reinterpret_cast<uint32_t*>(managed_sp);
+
+    // Push local reference frame.
+    JNIEnvExt* env = self->GetJniEnv();
+    DCHECK(env != nullptr);
+    uint32_t cookie = bit_cast<uint32_t>(env->GetLocalRefCookie());
+    env->SetLocalRefCookie(env->GetLocalsSegmentState());
+
+    // Save the cookie on the stack.
+    uint32_t* sp32 = reinterpret_cast<uint32_t*>(managed_sp);
     *(sp32 - 1) = cookie;
   }
 

--- a/runtime/entrypoints/quick/quick_trampoline_entrypoints.cc
+++ b/runtime/entrypoints/quick/quick_trampoline_entrypoints.cc
@@ -874,9 +874,7 @@ extern "C" uint64_t artQuickProxyInvokeHandler(
     }
   } else if (instr->HasMethodExitListeners()) {
     instr->MethodExitEvent(self,
-                           soa.Decode<mirror::Object>(rcvr_jobj),
                            proxy_method,
-                           0,
                            {},
                            result);
   }

--- a/runtime/gc/collector/concurrent_copying.cc
+++ b/runtime/gc/collector/concurrent_copying.cc
@@ -2332,7 +2332,7 @@ inline void ConcurrentCopying::ProcessMarkStackRef(mirror::Object* to_ref) {
         // TODO: Temporary; remove this when this is no longer needed (b/116087961).
         << " runtime->sentinel=" << Runtime::Current()->GetSentinel().Read<kWithoutReadBarrier>();
   }
-#ifdef USE_BAKER_OR_BROOKS_READ_BARRIER
+#ifdef USE_BAKER_READ_BARRIER
   mirror::Object* referent = nullptr;
   if (UNLIKELY((to_ref->GetClass<kVerifyNone, kWithoutReadBarrier>()->IsTypeOfReferenceClass() &&
                 (referent = to_ref->AsReference()->GetReferent<kWithoutReadBarrier>()) != nullptr &&

--- a/runtime/gc/heap.cc
+++ b/runtime/gc/heap.cc
@@ -1531,6 +1531,7 @@ void Heap::TrimIndirectReferenceTables(Thread* self) {
   // Trim globals indirect reference table.
   vm->TrimGlobals();
   // Trim locals indirect reference tables.
+  // TODO: May also want to look for entirely empty pages maintained by SmallIrtAllocator.
   Barrier barrier(0);
   TrimIndirectReferenceTableClosure closure(&barrier);
   ScopedThreadStateChange tsc(self, kWaitingForCheckPointsToRun);

--- a/runtime/gc/heap.cc
+++ b/runtime/gc/heap.cc
@@ -22,6 +22,9 @@
 #include <malloc.h>  // For mallinfo()
 #endif
 #include <memory>
+#include <random>
+#include <unistd.h>
+#include <sys/types.h>
 #include <vector>
 
 #include "android-base/stringprintf.h"
@@ -316,6 +319,7 @@ Heap::Heap(size_t initial_size,
       next_gc_type_(collector::kGcTypePartial),
       capacity_(capacity),
       growth_limit_(growth_limit),
+      initial_heap_size_(initial_size),
       target_footprint_(initial_size),
       // Using kPostMonitorLock as a lock at kDefaultMutexLevel is acquired after
       // this one.
@@ -2129,6 +2133,27 @@ HomogeneousSpaceCompactResult Heap::PerformHomogeneousSpaceCompact() {
   return HomogeneousSpaceCompactResult::kSuccess;
 }
 
+void Heap::SetDefaultConcurrentStartBytes() {
+  MutexLock mu(Thread::Current(), *gc_complete_lock_);
+  if (collector_type_running_ != kCollectorTypeNone) {
+    // If a collector is already running, just let it set concurrent_start_bytes_ .
+    return;
+  }
+  SetDefaultConcurrentStartBytesLocked();
+}
+
+void Heap::SetDefaultConcurrentStartBytesLocked() {
+  if (IsGcConcurrent()) {
+    size_t target_footprint = target_footprint_.load(std::memory_order_relaxed);
+    size_t reserve_bytes = target_footprint / 4;
+    reserve_bytes = std::min(reserve_bytes, kMaxConcurrentRemainingBytes);
+    reserve_bytes = std::max(reserve_bytes, kMinConcurrentRemainingBytes);
+    concurrent_start_bytes_ = UnsignedDifference(target_footprint, reserve_bytes);
+  } else {
+    concurrent_start_bytes_ = std::numeric_limits<size_t>::max();
+  }
+}
+
 void Heap::ChangeCollector(CollectorType collector_type) {
   // TODO: Only do this with all mutators suspended to avoid races.
   if (collector_type != collector_type_) {
@@ -2175,13 +2200,7 @@ void Heap::ChangeCollector(CollectorType collector_type) {
         UNREACHABLE();
       }
     }
-    if (IsGcConcurrent()) {
-      concurrent_start_bytes_ =
-          UnsignedDifference(target_footprint_.load(std::memory_order_relaxed),
-                             kMinConcurrentRemainingBytes);
-    } else {
-      concurrent_start_bytes_ = std::numeric_limits<size_t>::max();
-    }
+    SetDefaultConcurrentStartBytesLocked();
   }
 }
 
@@ -3545,6 +3564,11 @@ double Heap::HeapGrowthMultiplier() const {
 
 void Heap::GrowForUtilization(collector::GarbageCollector* collector_ran,
                               size_t bytes_allocated_before_gc) {
+  // We're running in the thread that set collector_type_running_ to something other than none,
+  // thus ensuring that there is only one of us running. Thus
+  // collector_type_running_ != kCollectorTypeNone, but that's a little tricky to turn into a
+  // DCHECK.
+
   // We know what our utilization is at this moment.
   // This doesn't actually resize any memory. It just lets the heap grow more when necessary.
   const size_t bytes_allocated = GetBytesAllocated();
@@ -3670,8 +3694,7 @@ void Heap::ClearGrowthLimit() {
   if (target_footprint_.load(std::memory_order_relaxed) == growth_limit_
       && growth_limit_ < capacity_) {
     target_footprint_.store(capacity_, std::memory_order_relaxed);
-    concurrent_start_bytes_ =
-        UnsignedDifference(capacity_, kMinConcurrentRemainingBytes);
+    SetDefaultConcurrentStartBytes();
   }
   growth_limit_ = capacity_;
   ScopedObjectAccess soa(Thread::Current());
@@ -4438,32 +4461,97 @@ void Heap::VlogHeapGrowth(size_t old_footprint, size_t new_footprint, size_t all
              << PrettySize(new_footprint) << " for a " << PrettySize(alloc_size) << " allocation";
 }
 
+// Run a gc if we haven't run one since initial_gc_num. This forces processes to
+// reclaim memory allocated during startup, even if they don't do much
+// allocation post startup. If the process is actively allocating and triggering
+// GCs, or has moved to the background and hence forced a GC, this does nothing.
 class Heap::TriggerPostForkCCGcTask : public HeapTask {
  public:
-  explicit TriggerPostForkCCGcTask(uint64_t target_time) : HeapTask(target_time) {}
+  explicit TriggerPostForkCCGcTask(uint64_t target_time, uint32_t initial_gc_num) :
+      HeapTask(target_time), initial_gc_num_(initial_gc_num) {}
   void Run(Thread* self) override {
     gc::Heap* heap = Runtime::Current()->GetHeap();
-    // Trigger a GC, if not already done. The first GC after fork, whenever it
-    // takes place, will adjust the thresholds to normal levels.
-    if (heap->target_footprint_.load(std::memory_order_relaxed) == heap->growth_limit_) {
-      heap->RequestConcurrentGC(self, kGcCauseBackground, false, heap->GetCurrentGcNum());
+    if (heap->GetCurrentGcNum() == initial_gc_num_) {
+      if (kLogAllGCs) {
+        LOG(INFO) << "Forcing GC for allocation-inactive process";
+      }
+      heap->RequestConcurrentGC(self, kGcCauseBackground, false, initial_gc_num_);
     }
   }
+ private:
+  uint32_t initial_gc_num_;
 };
 
+// Reduce target footprint, if no GC has occurred since initial_gc_num.
+// If a GC already occurred, it will have done this for us.
+class Heap::ReduceTargetFootprintTask : public HeapTask {
+ public:
+  explicit ReduceTargetFootprintTask(uint64_t target_time, size_t new_target_sz,
+                                     uint32_t initial_gc_num) :
+      HeapTask(target_time), new_target_sz_(new_target_sz), initial_gc_num_(initial_gc_num) {}
+  void Run(Thread* self) override {
+    gc::Heap* heap = Runtime::Current()->GetHeap();
+    MutexLock mu(self, *(heap->gc_complete_lock_));
+    if (heap->GetCurrentGcNum() == initial_gc_num_
+        && heap->collector_type_running_ == kCollectorTypeNone) {
+      size_t target_footprint = heap->target_footprint_.load(std::memory_order_relaxed);
+      if (target_footprint > new_target_sz_) {
+        if (heap->target_footprint_.CompareAndSetStrongRelaxed(target_footprint, new_target_sz_)) {
+          heap->SetDefaultConcurrentStartBytesLocked();
+        }
+      }
+    }
+  }
+ private:
+  size_t new_target_sz_;
+  uint32_t initial_gc_num_;
+};
+
+// Return a pseudo-random integer between 0 and 19999, using the uid as a seed.  We want this to
+// be deterministic for a given process, but to vary randomly across processes. Empirically, the
+// uids for processes for which this matters are distinct.
+static uint32_t GetPseudoRandomFromUid() {
+  std::default_random_engine rng(getuid());
+  std::uniform_int_distribution<int> dist(0, 19999);
+  return dist(rng);
+}
+
 void Heap::PostForkChildAction(Thread* self) {
+  uint32_t starting_gc_num = GetCurrentGcNum();
+  uint64_t last_adj_time = NanoTime();
+  next_gc_type_ = NonStickyGcType();  // Always start with a full gc.
+
   // Temporarily increase target_footprint_ and concurrent_start_bytes_ to
   // max values to avoid GC during app launch.
-  if (collector_type_ == kCollectorTypeCC && !IsLowMemoryMode()) {
+  if (!IsLowMemoryMode()) {
     // Set target_footprint_ to the largest allowed value.
     SetIdealFootprint(growth_limit_);
-    // Set concurrent_start_bytes_ to half of the heap size.
-    size_t target_footprint = target_footprint_.load(std::memory_order_relaxed);
-    concurrent_start_bytes_ = std::max(target_footprint / 2, GetBytesAllocated());
+    SetDefaultConcurrentStartBytes();
 
-    GetTaskProcessor()->AddTask(
-        self, new TriggerPostForkCCGcTask(NanoTime() + MsToNs(kPostForkMaxHeapDurationMS)));
+    // Shrink heap after kPostForkMaxHeapDurationMS, to force a memory hog process to GC.
+    // This remains high enough that many processes will continue without a GC.
+    if (initial_heap_size_ < growth_limit_) {
+      size_t first_shrink_size = std::max(growth_limit_ / 4, initial_heap_size_);
+      last_adj_time += MsToNs(kPostForkMaxHeapDurationMS);
+      GetTaskProcessor()->AddTask(
+          self, new ReduceTargetFootprintTask(last_adj_time, first_shrink_size, starting_gc_num));
+      // Shrink to a small value after a substantial time period. This will typically force a
+      // GC if none has occurred yet. Has no effect if there was a GC before this anyway, which
+      // is commonly the case, e.g. because of a process transition.
+      if (initial_heap_size_ < first_shrink_size) {
+        last_adj_time += MsToNs(4 * kPostForkMaxHeapDurationMS);
+        GetTaskProcessor()->AddTask(
+            self,
+            new ReduceTargetFootprintTask(last_adj_time, initial_heap_size_, starting_gc_num));
+      }
+    }
   }
+  // Schedule a GC after a substantial period of time. This will become a no-op if another GC is
+  // scheduled in the interim. If not, we want to avoid holding onto start-up garbage.
+  uint64_t post_fork_gc_time = last_adj_time
+      + MsToNs(4 * kPostForkMaxHeapDurationMS + GetPseudoRandomFromUid());
+  GetTaskProcessor()->AddTask(self,
+                              new TriggerPostForkCCGcTask(post_fork_gc_time, starting_gc_num));
 }
 
 void Heap::VisitReflectiveTargets(ReflectiveValueVisitor *visit) {

--- a/runtime/gc/heap.cc
+++ b/runtime/gc/heap.cc
@@ -333,6 +333,7 @@ Heap::Heap(size_t initial_size,
       old_native_bytes_allocated_(0),
       native_objects_notified_(0),
       num_bytes_freed_revoke_(0),
+      num_bytes_alive_after_gc_(0),
       verify_missing_card_marks_(false),
       verify_system_weaks_(false),
       verify_pre_gc_heap_(verify_pre_gc_heap),
@@ -2720,6 +2721,7 @@ collector::GcType Heap::CollectGarbageInternal(collector::GcType gc_type,
   // Grow the heap so that we know when to perform the next GC.
   GrowForUtilization(collector, bytes_allocated_before_gc);
   old_native_bytes_allocated_.store(GetNativeBytes());
+  num_bytes_alive_after_gc_ = bytes_allocated_before_gc - current_gc_iteration_.GetFreedBytes();
   LogGC(gc_cause, collector);
   FinishGC(self, gc_type);
   // Actually enqueue all cleared references. Do this after the GC has officially finished since
@@ -3841,6 +3843,16 @@ void Heap::RequestCollectorTransition(CollectorType desired_collector_type, uint
     // For CC, we invoke a full compaction when going to the background, but the collector type
     // doesn't change.
     DCHECK_EQ(desired_collector_type_, kCollectorTypeCCBackground);
+    // App's allocations (since last GC) more than the threshold then do TransitionGC
+    // when the app was in background. If not then don't do TransitionGC.
+    size_t num_bytes_allocated_since_gc = GetBytesAllocated() - num_bytes_alive_after_gc_;
+    if (num_bytes_allocated_since_gc <
+        (UnsignedDifference(target_footprint_.load(std::memory_order_relaxed),
+                            num_bytes_alive_after_gc_)/4)
+        && !kStressCollectorTransition
+        && !IsLowMemoryMode()) {
+      return;
+    }
   }
   DCHECK_NE(collector_type_, kCollectorTypeCCBackground);
   CollectorTransitionTask* added_task = nullptr;

--- a/runtime/gc/heap.h
+++ b/runtime/gc/heap.h
@@ -330,9 +330,10 @@ class Heap {
   void ChangeAllocator(AllocatorType allocator)
       REQUIRES(Locks::mutator_lock_, !Locks::runtime_shutdown_lock_);
 
-  // Change the collector to be one of the possible options (MS, CMS, SS).
+  // Change the collector to be one of the possible options (MS, CMS, SS). Only safe when no
+  // concurrent accesses to the heap are possible.
   void ChangeCollector(CollectorType collector_type)
-      REQUIRES(Locks::mutator_lock_);
+      REQUIRES(Locks::mutator_lock_, !*gc_complete_lock_);
 
   // The given reference is believed to be to an object in the Java heap, check the soundness of it.
   // TODO: NO_THREAD_SAFETY_ANALYSIS since we call this everywhere and it is impossible to find a
@@ -405,7 +406,7 @@ class Heap {
 
   // Removes the growth limit on the alloc space so it may grow to its maximum capacity. Used to
   // implement dalvik.system.VMRuntime.clearGrowthLimit.
-  void ClearGrowthLimit();
+  void ClearGrowthLimit() REQUIRES(!*gc_complete_lock_);
 
   // Make the current growth limit the new maximum capacity, unmaps pages at the end of spaces
   // which will never be used. Used to implement dalvik.system.VMRuntime.clampGrowthLimit.
@@ -458,6 +459,7 @@ class Heap {
 
   // For the alloc space, sets the maximum number of bytes that the heap is allowed to allocate
   // from the system. Doesn't allow the space to exceed its growth limit.
+  // Set while we hold gc_complete_lock or collector_type_running_ != kCollectorTypeNone.
   void SetIdealFootprint(size_t max_allowed_footprint);
 
   // Blocks the caller until the garbage collector becomes idle and returns the type of GC we
@@ -954,7 +956,7 @@ class Heap {
 
   const Verification* GetVerification() const;
 
-  void PostForkChildAction(Thread* self);
+  void PostForkChildAction(Thread* self) REQUIRES(!*gc_complete_lock_);
 
   void TraceHeapSize(size_t heap_size);
 
@@ -965,6 +967,7 @@ class Heap {
   class CollectorTransitionTask;
   class HeapTrimTask;
   class TriggerPostForkCCGcTask;
+  class ReduceTargetFootprintTask;
 
   // Compact source space to target space. Returns the collector used.
   collector::GarbageCollector* Compact(space::ContinuousMemMapAllocSpace* target_space,
@@ -1171,6 +1174,9 @@ class Heap {
   // the target utilization ratio.  This should only be called immediately after a full garbage
   // collection. bytes_allocated_before_gc is used to measure bytes / second for the period which
   // the GC was run.
+  // This is only called by the thread that set collector_type_running_ to a value other than
+  // kCollectorTypeNone, or while holding gc_complete_lock, and ensuring that
+  // collector_type_running_ is kCollectorTypeNone.
   void GrowForUtilization(collector::GarbageCollector* collector_ran,
                           size_t bytes_allocated_before_gc = 0)
       REQUIRES(!process_state_update_lock_);
@@ -1262,6 +1268,11 @@ class Heap {
   // are currently in use, and could possibly be reclaimed as an indirect result
   // of a garbage collection.
   size_t GetNativeBytes();
+
+  // Set concurrent_start_bytes_ to a reasonable guess, given target_footprint_ .
+  void SetDefaultConcurrentStartBytes() REQUIRES(!*gc_complete_lock_);
+  // This version assumes no concurrent updaters.
+  void SetDefaultConcurrentStartBytesLocked();
 
   // All-known continuous spaces, where objects lie within fixed bounds.
   std::vector<space::ContinuousSpace*> continuous_spaces_ GUARDED_BY(Locks::mutator_lock_);
@@ -1379,6 +1390,9 @@ class Heap {
   // Task processor, proxies heap trim requests to the daemon threads.
   std::unique_ptr<TaskProcessor> task_processor_;
 
+  // The following are declared volatile only for debugging purposes; it shouldn't otherwise
+  // matter.
+
   // Collector type of the running GC.
   volatile CollectorType collector_type_running_ GUARDED_BY(gc_complete_lock_);
 
@@ -1400,21 +1414,29 @@ class Heap {
   // Only weakly enforced for simultaneous allocations.
   size_t growth_limit_;
 
+  // Requested initial heap size. Temporarily ignored after a fork, but then reestablished after
+  // a while to usually trigger the initial GC.
+  size_t initial_heap_size_;
+
   // Target size (as in maximum allocatable bytes) for the heap. Weakly enforced as a limit for
   // non-concurrent GC. Used as a guideline for computing concurrent_start_bytes_ in the
-  // concurrent GC case.
+  // concurrent GC case. Updates normally occur while collector_type_running_ is not none.
   Atomic<size_t> target_footprint_;
+
+  Mutex process_state_update_lock_ DEFAULT_MUTEX_ACQUIRED_AFTER;
 
   // Computed with foreground-multiplier in GrowForUtilization() when run in
   // jank non-perceptible state. On update to process state from background to
   // foreground we set target_footprint_ to this value.
-  Mutex process_state_update_lock_ DEFAULT_MUTEX_ACQUIRED_AFTER;
   size_t min_foreground_target_footprint_ GUARDED_BY(process_state_update_lock_);
 
   // When num_bytes_allocated_ exceeds this amount then a concurrent GC should be requested so that
   // it completes ahead of an allocation failing.
   // A multiple of this is also used to determine when to trigger a GC in response to native
   // allocation.
+  // After initialization, this is only updated by the thread that set collector_type_running_ to
+  // a value other than kCollectorTypeNone, or while holding gc_complete_lock, and ensuring that
+  // collector_type_running_ is kCollectorTypeNone.
   size_t concurrent_start_bytes_;
 
   // Since the heap was created, how many bytes have been freed.

--- a/runtime/gc/heap.h
+++ b/runtime/gc/heap.h
@@ -166,7 +166,7 @@ class Heap {
   // as object allocation time. time_to_call_mallinfo seems to be on the order of 1 usec
   // on Android.
 #ifdef __ANDROID__
-  static constexpr uint32_t kNotifyNativeInterval = 32;
+  static constexpr uint32_t kNotifyNativeInterval = 64;
 #else
   // Some host mallinfo() implementations are slow. And memory is less scarce.
   static constexpr uint32_t kNotifyNativeInterval = 384;
@@ -1467,6 +1467,10 @@ class Heap {
   // here to be subtracted from num_bytes_allocated_ later at the next
   // GC.
   Atomic<size_t> num_bytes_freed_revoke_;
+
+  // Records the number of bytes allocated at the time of GC, which is used later to calculate
+  // how many bytes have been allocated since the last GC
+  size_t num_bytes_alive_after_gc_;
 
   // Info related to the current or previous GC iteration.
   collector::Iteration current_gc_iteration_;

--- a/runtime/gc/reference_queue.cc
+++ b/runtime/gc/reference_queue.cc
@@ -75,7 +75,7 @@ ObjPtr<mirror::Reference> ReferenceQueue::DequeuePendingReference() {
 // This must be called whenever DequeuePendingReference is called.
 void ReferenceQueue::DisableReadBarrierForReference(ObjPtr<mirror::Reference> ref) {
   Heap* heap = Runtime::Current()->GetHeap();
-  if (kUseBakerOrBrooksReadBarrier && heap->CurrentCollectorType() == kCollectorTypeCC &&
+  if (kUseBakerReadBarrier && heap->CurrentCollectorType() == kCollectorTypeCC &&
       heap->ConcurrentCopyingCollector()->IsActive()) {
     // Change the gray ptr we left in ConcurrentCopying::ProcessMarkStackRef() to non-gray.
     // We check IsActive() above because we don't want to do this when the zygote compaction

--- a/runtime/indirect_reference_table-inl.h
+++ b/runtime/indirect_reference_table-inl.h
@@ -101,15 +101,15 @@ inline void IndirectReferenceTable::Update(IndirectRef iref, ObjPtr<mirror::Obje
 
 inline void IrtEntry::Add(ObjPtr<mirror::Object> obj) {
   ++serial_;
-  if (serial_ == kIRTPrevCount) {
+  if (serial_ == kIRTMaxSerial) {
     serial_ = 0;
   }
-  references_[serial_] = GcRoot<mirror::Object>(obj);
+  reference_ = GcRoot<mirror::Object>(obj);
 }
 
 inline void IrtEntry::SetReference(ObjPtr<mirror::Object> obj) {
-  DCHECK_LT(serial_, kIRTPrevCount);
-  references_[serial_] = GcRoot<mirror::Object>(obj);
+  DCHECK_LT(serial_, kIRTMaxSerial);
+  reference_ = GcRoot<mirror::Object>(obj);
 }
 
 }  // namespace art

--- a/runtime/indirect_reference_table.cc
+++ b/runtime/indirect_reference_table.cc
@@ -80,7 +80,7 @@ static inline MemMap NewIRTMap(size_t table_bytes, std::string* error_msg) {
 }
 
 SmallIrtAllocator::SmallIrtAllocator()
-    : small_irt_freelist_(nullptr), lock_("Small IRT table lock") {
+    : small_irt_freelist_(nullptr), lock_("Small IRT table lock", LockLevel::kGenericBottomLock) {
 }
 
 // Allocate an IRT table for kSmallIrtEntries.

--- a/runtime/indirect_reference_table.h
+++ b/runtime/indirect_reference_table.h
@@ -29,6 +29,7 @@
 #include "base/locks.h"
 #include "base/macros.h"
 #include "base/mem_map.h"
+#include "base/mutex.h"
 #include "gc_root.h"
 #include "obj_ptr.h"
 #include "offsets.h"
@@ -216,6 +217,39 @@ bool inline operator!=(const IrtIterator& lhs, const IrtIterator& rhs) {
   return !lhs.equals(rhs);
 }
 
+// We initially allocate local reference tables with a very small number of entries, packing
+// multiple tables into a single page. If we need to expand one, we allocate them in units of
+// pages.
+// TODO: We should allocate all IRT tables as nonmovable Java objects, That in turn works better
+// if we break up each table into 2 parallel arrays, one for the Java reference, and one for the
+// serial number. The current scheme page-aligns regions containing IRT tables, and so allows them
+// to be identified and page-protected in the future.
+constexpr size_t kInitialIrtBytes = 512;  // Number of bytes in an initial local table.
+constexpr size_t kSmallIrtEntries = kInitialIrtBytes / sizeof(IrtEntry);
+static_assert(kPageSize % kInitialIrtBytes == 0);
+static_assert(kInitialIrtBytes % sizeof(IrtEntry) == 0);
+static_assert(kInitialIrtBytes % sizeof(void *) == 0);
+
+// A minimal stopgap allocator for initial small local IRT tables.
+class SmallIrtAllocator {
+ public:
+  SmallIrtAllocator();
+
+  // Allocate an IRT table for kSmallIrtEntries.
+  IrtEntry* Allocate(std::string* error_msg) REQUIRES(!lock_);
+
+  void Deallocate(IrtEntry* unneeded) REQUIRES(!lock_);
+
+ private:
+  // A free list of kInitialIrtBytes chunks linked through the first word.
+  IrtEntry* small_irt_freelist_;
+
+  // Repository of MemMaps used for small IRT tables.
+  std::vector<MemMap> shared_irt_maps_;
+
+  Mutex lock_;
+};
+
 class IndirectReferenceTable {
  public:
   enum class ResizableCapacity {
@@ -228,6 +262,8 @@ class IndirectReferenceTable {
   // construction has failed and the IndirectReferenceTable will be in an
   // invalid state. Use IsValid to check whether the object is in an invalid
   // state.
+  // Max_count is the minimum initial capacity (resizable), or minimum total capacity
+  // (not resizable). A value of 1 indicates an implementation-convenient small size.
   IndirectReferenceTable(size_t max_count,
                          IndirectRefKind kind,
                          ResizableCapacity resizable,
@@ -401,7 +437,8 @@ class IndirectReferenceTable {
   /// semi-public - read/write by jni down calls.
   IRTSegmentState segment_state_;
 
-  // Mem map where we store the indirect refs.
+  // Mem map where we store the indirect refs. If it's invalid, and table_ is non-null, then
+  // table_ is valid, but was allocated via allocSmallIRT();
   MemMap table_mem_map_;
   // bottom of the stack. Do not directly access the object references
   // in this as they are roots. Use Get() that has a read barrier.

--- a/runtime/indirect_reference_table.h
+++ b/runtime/indirect_reference_table.h
@@ -149,23 +149,22 @@ struct IRTSegmentState {
 // Use as initial value for "cookie", and when table has only one segment.
 static constexpr IRTSegmentState kIRTFirstSegment = { 0 };
 
-// Try to choose kIRTPrevCount so that sizeof(IrtEntry) is a power of 2.
-// Contains multiple entries but only one active one, this helps us detect use after free errors
-// since the serial stored in the indirect ref wont match.
-static constexpr size_t kIRTPrevCount = kIsDebugBuild ? 7 : 3;
+// We associate a few bits of serial number with each reference, for error checking.
+static constexpr unsigned int kIRTSerialBits = 3;
+static constexpr uint32_t kIRTMaxSerial = ((1 << kIRTSerialBits) - 1);
 
 class IrtEntry {
  public:
   void Add(ObjPtr<mirror::Object> obj) REQUIRES_SHARED(Locks::mutator_lock_);
 
   GcRoot<mirror::Object>* GetReference() {
-    DCHECK_LT(serial_, kIRTPrevCount);
-    return &references_[serial_];
+    DCHECK_LE(serial_, kIRTMaxSerial);
+    return &reference_;
   }
 
   const GcRoot<mirror::Object>* GetReference() const {
-    DCHECK_LT(serial_, kIRTPrevCount);
-    return &references_[serial_];
+    DCHECK_LE(serial_, kIRTMaxSerial);
+    return &reference_;
   }
 
   uint32_t GetSerial() const {
@@ -175,11 +174,10 @@ class IrtEntry {
   void SetReference(ObjPtr<mirror::Object> obj) REQUIRES_SHARED(Locks::mutator_lock_);
 
  private:
-  uint32_t serial_;
-  GcRoot<mirror::Object> references_[kIRTPrevCount];
+  uint32_t serial_;  // Incremented for each reuse; checked against reference.
+  GcRoot<mirror::Object> reference_;
 };
-static_assert(sizeof(IrtEntry) == (1 + kIRTPrevCount) * sizeof(uint32_t),
-              "Unexpected sizeof(IrtEntry)");
+static_assert(sizeof(IrtEntry) == 2 * sizeof(uint32_t), "Unexpected sizeof(IrtEntry)");
 static_assert(IsPowerOfTwo(sizeof(IrtEntry)), "Unexpected sizeof(IrtEntry)");
 
 class IrtIterator {
@@ -340,8 +338,7 @@ class IndirectReferenceTable {
       REQUIRES_SHARED(Locks::mutator_lock_);
 
  private:
-  static constexpr size_t kSerialBits = MinimumBitsToStore(kIRTPrevCount);
-  static constexpr uint32_t kShiftedSerialMask = (1u << kSerialBits) - 1;
+  static constexpr uint32_t kShiftedSerialMask = (1u << kIRTSerialBits) - 1;
 
   static constexpr size_t kKindBits = MinimumBitsToStore(
       static_cast<uint32_t>(IndirectRefKind::kLastKind));
@@ -349,11 +346,11 @@ class IndirectReferenceTable {
 
   static constexpr uintptr_t EncodeIndex(uint32_t table_index) {
     static_assert(sizeof(IndirectRef) == sizeof(uintptr_t), "Unexpected IndirectRef size");
-    DCHECK_LE(MinimumBitsToStore(table_index), BitSizeOf<uintptr_t>() - kSerialBits - kKindBits);
-    return (static_cast<uintptr_t>(table_index) << kKindBits << kSerialBits);
+    DCHECK_LE(MinimumBitsToStore(table_index), BitSizeOf<uintptr_t>() - kIRTSerialBits - kKindBits);
+    return (static_cast<uintptr_t>(table_index) << kKindBits << kIRTSerialBits);
   }
   static constexpr uint32_t DecodeIndex(uintptr_t uref) {
-    return static_cast<uint32_t>((uref >> kKindBits) >> kSerialBits);
+    return static_cast<uint32_t>((uref >> kKindBits) >> kIRTSerialBits);
   }
 
   static constexpr uintptr_t EncodeIndirectRefKind(IndirectRefKind kind) {
@@ -364,7 +361,7 @@ class IndirectReferenceTable {
   }
 
   static constexpr uintptr_t EncodeSerial(uint32_t serial) {
-    DCHECK_LE(MinimumBitsToStore(serial), kSerialBits);
+    DCHECK_LE(MinimumBitsToStore(serial), kIRTSerialBits);
     return serial << kKindBits;
   }
   static constexpr uint32_t DecodeSerial(uintptr_t uref) {

--- a/runtime/indirect_reference_table.h
+++ b/runtime/indirect_reference_table.h
@@ -247,7 +247,7 @@ class SmallIrtAllocator {
   // Repository of MemMaps used for small IRT tables.
   std::vector<MemMap> shared_irt_maps_;
 
-  Mutex lock_;
+  Mutex lock_;  // Level kGenericBottomLock; acquired before mem_map_lock_, which is a C++ mutex.
 };
 
 class IndirectReferenceTable {

--- a/runtime/instrumentation.cc
+++ b/runtime/instrumentation.cc
@@ -59,9 +59,7 @@ constexpr bool kVerboseInstrumentation = false;
 
 void InstrumentationListener::MethodExited(
     Thread* thread,
-    Handle<mirror::Object> this_object,
     ArtMethod* method,
-    uint32_t dex_pc,
     OptionalFrame frame,
     MutableHandle<mirror::Object>& return_value) {
   DCHECK_EQ(method->GetInterfaceMethodIfProxy(kRuntimePointerSize)->GetReturnTypePrimitive(),
@@ -69,7 +67,7 @@ void InstrumentationListener::MethodExited(
   const void* original_ret = return_value.Get();
   JValue v;
   v.SetL(return_value.Get());
-  MethodExited(thread, this_object, method, dex_pc, frame, v);
+  MethodExited(thread, method, frame, v);
   DCHECK(original_ret == v.GetL()) << "Return value changed";
 }
 
@@ -307,7 +305,6 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
           instrumentation_stack_(thread_in->GetInstrumentationStack()),
           instrumentation_exit_pc_(instrumentation_exit_pc),
           reached_existing_instrumentation_frames_(false),
-          last_return_pc_(0),
           force_deopt_id_(force_deopt_id) {}
 
     bool VisitFrame() override REQUIRES_SHARED(Locks::mutator_lock_) {
@@ -316,7 +313,6 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
         if (kVerboseInstrumentation) {
           LOG(INFO) << "  Skipping upcall. Frame " << GetFrameId();
         }
-        last_return_pc_ = 0;
         return true;  // Ignore upcalls.
       }
       if (GetCurrentQuickFrame() == nullptr) {
@@ -343,13 +339,6 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
         const InstrumentationStackFrame& frame = it->second;
         if (m->IsRuntimeMethod()) {
           if (frame.interpreter_entry_) {
-            // This instrumentation frame is for an interpreter bridge and is
-            // pushed when executing the instrumented interpreter bridge. So method
-            // enter event must have been reported. However we need to push a DEX pc
-            // into the dex_pcs_ list to match size of instrumentation stack.
-            uint32_t dex_pc = dex::kDexNoIndex;
-            dex_pcs_.push_back(dex_pc);
-            last_return_pc_ = frame.return_pc_;
             return true;
           }
         }
@@ -372,16 +361,10 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
           // inserted by the interpreter or runtime.
           std::string thread_name;
           GetThread()->GetThreadName(thread_name);
-          uint32_t dex_pc = dex::kDexNoIndex;
-          if (last_return_pc_ != 0 && GetCurrentOatQuickMethodHeader() != nullptr) {
-            dex_pc = GetCurrentOatQuickMethodHeader()->ToDexPc(
-                GetCurrentQuickFrame(), last_return_pc_);
-          }
           LOG(FATAL) << "While walking " << thread_name << " found unexpected non-runtime method"
                      << " without instrumentation exit return or interpreter frame."
                      << " method is " << GetMethod()->PrettyMethod()
-                     << " return_pc is " << std::hex << return_pc
-                     << " dex pc: " << dex_pc;
+                     << " return_pc is " << std::hex << return_pc;
           UNREACHABLE();
         }
         InstrumentationStackFrame instrumentation_frame(
@@ -398,20 +381,12 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
         instrumentation_stack_->insert({GetReturnPcAddr(), instrumentation_frame});
         SetReturnPc(instrumentation_exit_pc_);
       }
-      uint32_t dex_pc = dex::kDexNoIndex;
-      if (last_return_pc_ != 0 && GetCurrentOatQuickMethodHeader() != nullptr) {
-        dex_pc = GetCurrentOatQuickMethodHeader()->ToDexPc(GetCurrentQuickFrame(), last_return_pc_);
-      }
-      dex_pcs_.push_back(dex_pc);
-      last_return_pc_ = return_pc;
       return true;  // Continue.
     }
     std::map<uintptr_t, InstrumentationStackFrame>* const instrumentation_stack_;
     std::vector<InstrumentationStackFrame> shadow_stack_;
-    std::vector<uint32_t> dex_pcs_;
     const uintptr_t instrumentation_exit_pc_;
     bool reached_existing_instrumentation_frames_;
-    uintptr_t last_return_pc_;
     uint64_t force_deopt_id_;
   };
   if (kVerboseInstrumentation) {
@@ -426,7 +401,6 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
   InstallStackVisitor visitor(
       thread, context.get(), instrumentation_exit_pc, instrumentation->current_force_deopt_id_);
   visitor.WalkStack(true);
-  CHECK_EQ(visitor.dex_pcs_.size(), thread->GetInstrumentationStack()->size());
 
   if (instrumentation->ShouldNotifyMethodEnterExitEvents()) {
     // Create method enter events for all methods currently on the thread's stack. We only do this
@@ -440,7 +414,6 @@ void InstrumentationInstallStack(Thread* thread, void* arg)
         instrumentation->MethodEnterEvent(thread, (*ssi).method_);
         ++ssi;
       }
-      visitor.dex_pcs_.pop_back();
       if (!isi->second.interpreter_entry_ && !isi->second.method_->IsRuntimeMethod()) {
         instrumentation->MethodEnterEvent(thread, isi->second.method_);
       }
@@ -507,8 +480,7 @@ static void InstrumentationRestoreStack(Thread* thread, void* arg)
           // Create the method exit events. As the methods didn't really exit the result is 0.
           // We only do this if no debugger is attached to prevent from posting events twice.
           JValue val;
-          instrumentation_->MethodExitEvent(thread_, instrumentation_frame.this_object_, m,
-                                            GetDexPc(), OptionalFrame{}, val);
+          instrumentation_->MethodExitEvent(thread_, m, OptionalFrame{}, val);
         }
         frames_removed_++;
       } else {
@@ -1189,43 +1161,35 @@ void Instrumentation::MethodEnterEventImpl(Thread* thread, ArtMethod* method) co
 
 template <>
 void Instrumentation::MethodExitEventImpl(Thread* thread,
-                                          ObjPtr<mirror::Object> this_object,
                                           ArtMethod* method,
-                                          uint32_t dex_pc,
                                           OptionalFrame frame,
                                           MutableHandle<mirror::Object>& return_value) const {
   if (HasMethodExitListeners()) {
-    Thread* self = Thread::Current();
-    StackHandleScope<1> hs(self);
-    Handle<mirror::Object> thiz(hs.NewHandle(this_object));
     for (InstrumentationListener* listener : method_exit_listeners_) {
       if (listener != nullptr) {
-        listener->MethodExited(thread, thiz, method, dex_pc, frame, return_value);
+        listener->MethodExited(thread, method, frame, return_value);
       }
     }
   }
 }
 
 template<> void Instrumentation::MethodExitEventImpl(Thread* thread,
-                                                     ObjPtr<mirror::Object> this_object,
                                                      ArtMethod* method,
-                                                     uint32_t dex_pc,
                                                      OptionalFrame frame,
                                                      JValue& return_value) const {
   if (HasMethodExitListeners()) {
     Thread* self = Thread::Current();
-    StackHandleScope<2> hs(self);
-    Handle<mirror::Object> thiz(hs.NewHandle(this_object));
+    StackHandleScope<1> hs(self);
     if (method->GetInterfaceMethodIfProxy(kRuntimePointerSize)->GetReturnTypePrimitive() !=
         Primitive::kPrimNot) {
       for (InstrumentationListener* listener : method_exit_listeners_) {
         if (listener != nullptr) {
-          listener->MethodExited(thread, thiz, method, dex_pc, frame, return_value);
+          listener->MethodExited(thread, method, frame, return_value);
         }
       }
     } else {
       MutableHandle<mirror::Object> ret(hs.NewHandle(return_value.GetL()));
-      MethodExitEventImpl(thread, thiz.Get(), method, dex_pc, frame, ret);
+      MethodExitEventImpl(thread, method, frame, ret);
       return_value.SetL(ret.Get());
     }
   }
@@ -1518,14 +1482,9 @@ TwoWordReturn Instrumentation::PopInstrumentationStackFrame(Thread* self,
     // Take a handle to the return value so we won't lose it if we suspend.
     res.Assign(return_value.GetL());
   }
-  // TODO: improve the dex pc information here, requires knowledge of current PC as opposed to
-  //       return_pc.
-  uint32_t dex_pc = dex::kDexNoIndex;
   if (!method->IsRuntimeMethod() && !instrumentation_frame.interpreter_entry_) {
-    ObjPtr<mirror::Object> this_object = instrumentation_frame.this_object_;
     // Note that sending the event may change the contents of *return_pc_addr.
-    MethodExitEvent(
-        self, this_object, instrumentation_frame.method_, dex_pc, OptionalFrame{}, return_value);
+    MethodExitEvent(self, instrumentation_frame.method_, OptionalFrame{}, return_value);
   }
 
   // Deoptimize if the caller needs to continue execution in the interpreter. Do nothing if we get

--- a/runtime/instrumentation.h
+++ b/runtime/instrumentation.h
@@ -75,10 +75,8 @@ struct InstrumentationListener {
   virtual ~InstrumentationListener() {}
 
   // Call-back for when a method is entered.
-  virtual void MethodEntered(Thread* thread,
-                             Handle<mirror::Object> this_object,
-                             ArtMethod* method,
-                             uint32_t dex_pc) REQUIRES_SHARED(Locks::mutator_lock_) = 0;
+  virtual void MethodEntered(Thread* thread, ArtMethod* method)
+      REQUIRES_SHARED(Locks::mutator_lock_) = 0;
 
   virtual void MethodExited(Thread* thread,
                             Handle<mirror::Object> this_object,
@@ -398,13 +396,10 @@ class Instrumentation {
 
   // Inform listeners that a method has been entered. A dex PC is provided as we may install
   // listeners into executing code and get method enter events for methods already on the stack.
-  void MethodEnterEvent(Thread* thread,
-                        ObjPtr<mirror::Object> this_object,
-                        ArtMethod* method,
-                        uint32_t dex_pc) const
+  void MethodEnterEvent(Thread* thread, ArtMethod* method) const
       REQUIRES_SHARED(Locks::mutator_lock_) {
     if (UNLIKELY(HasMethodEntryListeners())) {
-      MethodEnterEventImpl(thread, this_object, method, dex_pc);
+      MethodEnterEventImpl(thread, method);
     }
   }
 
@@ -597,10 +592,7 @@ class Instrumentation {
   // exclusive access to mutator lock which you can't get if the runtime isn't started.
   void SetEntrypointsInstrumented(bool instrumented) NO_THREAD_SAFETY_ANALYSIS;
 
-  void MethodEnterEventImpl(Thread* thread,
-                            ObjPtr<mirror::Object> this_object,
-                            ArtMethod* method,
-                            uint32_t dex_pc) const
+  void MethodEnterEventImpl(Thread* thread, ArtMethod* method) const
       REQUIRES_SHARED(Locks::mutator_lock_);
   template <typename T>
   void MethodExitEventImpl(Thread* thread,

--- a/runtime/instrumentation.h
+++ b/runtime/instrumentation.h
@@ -79,9 +79,7 @@ struct InstrumentationListener {
       REQUIRES_SHARED(Locks::mutator_lock_) = 0;
 
   virtual void MethodExited(Thread* thread,
-                            Handle<mirror::Object> this_object,
                             ArtMethod* method,
-                            uint32_t dex_pc,
                             OptionalFrame frame,
                             MutableHandle<mirror::Object>& return_value)
       REQUIRES_SHARED(Locks::mutator_lock_);
@@ -90,9 +88,7 @@ struct InstrumentationListener {
   // value (if appropriate) or use the alternate MethodExited callback instead if they need to
   // go through a suspend point.
   virtual void MethodExited(Thread* thread,
-                            Handle<mirror::Object> this_object,
                             ArtMethod* method,
-                            uint32_t dex_pc,
                             OptionalFrame frame,
                             JValue& return_value)
       REQUIRES_SHARED(Locks::mutator_lock_) = 0;
@@ -406,14 +402,12 @@ class Instrumentation {
   // Inform listeners that a method has been exited.
   template<typename T>
   void MethodExitEvent(Thread* thread,
-                       ObjPtr<mirror::Object> this_object,
                        ArtMethod* method,
-                       uint32_t dex_pc,
                        OptionalFrame frame,
                        T& return_value) const
       REQUIRES_SHARED(Locks::mutator_lock_) {
     if (UNLIKELY(HasMethodExitListeners())) {
-      MethodExitEventImpl(thread, this_object, method, dex_pc, frame, return_value);
+      MethodExitEventImpl(thread, method, frame, return_value);
     }
   }
 
@@ -596,9 +590,7 @@ class Instrumentation {
       REQUIRES_SHARED(Locks::mutator_lock_);
   template <typename T>
   void MethodExitEventImpl(Thread* thread,
-                           ObjPtr<mirror::Object> this_object,
                            ArtMethod* method,
-                           uint32_t dex_pc,
                            OptionalFrame frame,
                            T& return_value) const
       REQUIRES_SHARED(Locks::mutator_lock_);

--- a/runtime/instrumentation_test.cc
+++ b/runtime/instrumentation_test.cc
@@ -55,11 +55,8 @@ class TestInstrumentationListener final : public instrumentation::Instrumentatio
 
   virtual ~TestInstrumentationListener() {}
 
-  void MethodEntered(Thread* thread ATTRIBUTE_UNUSED,
-                     Handle<mirror::Object> this_object ATTRIBUTE_UNUSED,
-                     ArtMethod* method ATTRIBUTE_UNUSED,
-                     uint32_t dex_pc ATTRIBUTE_UNUSED)
-      override REQUIRES_SHARED(Locks::mutator_lock_) {
+  void MethodEntered(Thread* thread ATTRIBUTE_UNUSED, ArtMethod* method ATTRIBUTE_UNUSED) override
+      REQUIRES_SHARED(Locks::mutator_lock_) {
     received_method_enter_event = true;
   }
 
@@ -392,7 +389,7 @@ class InstrumentationTest : public CommonRuntimeTest {
       REQUIRES_SHARED(Locks::mutator_lock_) {
     switch (event_type) {
       case instrumentation::Instrumentation::kMethodEntered:
-        instr->MethodEnterEvent(self, obj, method, dex_pc);
+        instr->MethodEnterEvent(self, method);
         break;
       case instrumentation::Instrumentation::kMethodExited: {
         JValue value;

--- a/runtime/instrumentation_test.cc
+++ b/runtime/instrumentation_test.cc
@@ -61,9 +61,7 @@ class TestInstrumentationListener final : public instrumentation::Instrumentatio
   }
 
   void MethodExited(Thread* thread ATTRIBUTE_UNUSED,
-                    Handle<mirror::Object> this_object ATTRIBUTE_UNUSED,
                     ArtMethod* method ATTRIBUTE_UNUSED,
-                    uint32_t dex_pc ATTRIBUTE_UNUSED,
                     instrumentation::OptionalFrame frame ATTRIBUTE_UNUSED,
                     MutableHandle<mirror::Object>& return_value ATTRIBUTE_UNUSED)
       override REQUIRES_SHARED(Locks::mutator_lock_) {
@@ -71,9 +69,7 @@ class TestInstrumentationListener final : public instrumentation::Instrumentatio
   }
 
   void MethodExited(Thread* thread ATTRIBUTE_UNUSED,
-                    Handle<mirror::Object> this_object ATTRIBUTE_UNUSED,
                     ArtMethod* method ATTRIBUTE_UNUSED,
-                    uint32_t dex_pc ATTRIBUTE_UNUSED,
                     instrumentation::OptionalFrame frame ATTRIBUTE_UNUSED,
                     JValue& return_value ATTRIBUTE_UNUSED)
       override REQUIRES_SHARED(Locks::mutator_lock_) {
@@ -393,7 +389,7 @@ class InstrumentationTest : public CommonRuntimeTest {
         break;
       case instrumentation::Instrumentation::kMethodExited: {
         JValue value;
-        instr->MethodExitEvent(self, obj, method, dex_pc, {}, value);
+        instr->MethodExitEvent(self, method, {}, value);
         break;
       }
       case instrumentation::Instrumentation::kMethodUnwind:

--- a/runtime/interpreter/interpreter.cc
+++ b/runtime/interpreter/interpreter.cc
@@ -301,12 +301,7 @@ static inline JValue Execute(
         DCHECK(Runtime::Current()->AreNonStandardExitsEnabled());
         JValue ret = JValue();
         PerformNonStandardReturn<MonitorState::kNoMonitorsLocked>(
-            self,
-            shadow_frame,
-            ret,
-            instrumentation,
-            accessor.InsSize(),
-            0);
+            self, shadow_frame, ret, instrumentation, accessor.InsSize());
         return ret;
       }
       if (UNLIKELY(self->IsExceptionPending())) {
@@ -318,12 +313,7 @@ static inline JValue Execute(
         if (UNLIKELY(shadow_frame.GetForcePopFrame())) {
           DCHECK(Runtime::Current()->AreNonStandardExitsEnabled());
           PerformNonStandardReturn<MonitorState::kNoMonitorsLocked>(
-              self,
-              shadow_frame,
-              ret,
-              instrumentation,
-              accessor.InsSize(),
-              0);
+              self, shadow_frame, ret, instrumentation, accessor.InsSize());
         }
         return ret;
       }

--- a/runtime/interpreter/interpreter.cc
+++ b/runtime/interpreter/interpreter.cc
@@ -294,10 +294,7 @@ static inline JValue Execute(
     ArtMethod *method = shadow_frame.GetMethod();
 
     if (UNLIKELY(instrumentation->HasMethodEntryListeners())) {
-      instrumentation->MethodEnterEvent(self,
-                                        shadow_frame.GetThisObject(accessor.InsSize()),
-                                        method,
-                                        0);
+      instrumentation->MethodEnterEvent(self, method);
       if (UNLIKELY(shadow_frame.GetForcePopFrame())) {
         // The caller will retry this invoke or ignore the result. Just return immediately without
         // any value.

--- a/runtime/interpreter/interpreter_common.cc
+++ b/runtime/interpreter/interpreter_common.cc
@@ -92,21 +92,16 @@ template <typename T>
 bool SendMethodExitEvents(Thread* self,
                           const instrumentation::Instrumentation* instrumentation,
                           ShadowFrame& frame,
-                          ObjPtr<mirror::Object> thiz,
                           ArtMethod* method,
-                          uint32_t dex_pc,
                           T& result) {
   bool had_event = false;
   // We can get additional ForcePopFrame requests during handling of these events. We should
   // respect these and send additional instrumentation events.
-  StackHandleScope<1> hs(self);
-  Handle<mirror::Object> h_thiz(hs.NewHandle(thiz));
   do {
     frame.SetForcePopFrame(false);
     if (UNLIKELY(instrumentation->HasMethodExitListeners() && !frame.GetSkipMethodExitEvents())) {
       had_event = true;
-      instrumentation->MethodExitEvent(
-          self, h_thiz.Get(), method, dex_pc, instrumentation::OptionalFrame{ frame }, result);
+      instrumentation->MethodExitEvent(self, method, instrumentation::OptionalFrame{frame}, result);
     }
     // We don't send method-exit if it's a pop-frame. We still send frame_popped though.
     if (UNLIKELY(frame.NeedsNotifyPop() && instrumentation->HasWatchedFramePopListeners())) {
@@ -125,18 +120,14 @@ template
 bool SendMethodExitEvents(Thread* self,
                           const instrumentation::Instrumentation* instrumentation,
                           ShadowFrame& frame,
-                          ObjPtr<mirror::Object> thiz,
                           ArtMethod* method,
-                          uint32_t dex_pc,
                           MutableHandle<mirror::Object>& result);
 
 template
 bool SendMethodExitEvents(Thread* self,
                           const instrumentation::Instrumentation* instrumentation,
                           ShadowFrame& frame,
-                          ObjPtr<mirror::Object> thiz,
                           ArtMethod* method,
-                          uint32_t dex_pc,
                           JValue& result);
 
 // We execute any instrumentation events that are triggered by this exception and change the

--- a/runtime/interpreter/interpreter_common.h
+++ b/runtime/interpreter/interpreter_common.h
@@ -143,9 +143,7 @@ template <typename T> bool SendMethodExitEvents(
     Thread* self,
     const instrumentation::Instrumentation* instrumentation,
     ShadowFrame& frame,
-    ObjPtr<mirror::Object> thiz,
     ArtMethod* method,
-    uint32_t dex_pc,
     T& result) REQUIRES_SHARED(Locks::mutator_lock_);
 
 static inline ALWAYS_INLINE WARN_UNUSED bool
@@ -200,12 +198,10 @@ static inline ALWAYS_INLINE void PerformNonStandardReturn(
       ShadowFrame& frame,
       JValue& result,
       const instrumentation::Instrumentation* instrumentation,
-      uint16_t num_dex_inst,
-      uint32_t dex_pc) REQUIRES_SHARED(Locks::mutator_lock_) {
+      uint16_t num_dex_inst) REQUIRES_SHARED(Locks::mutator_lock_) {
   static constexpr bool kMonitorCounting = (kMonitorState == MonitorState::kCountingMonitors);
   ObjPtr<mirror::Object> thiz(frame.GetThisObject(num_dex_inst));
   StackHandleScope<1u> hs(self);
-  Handle<mirror::Object> h_thiz(hs.NewHandle(thiz));
   if (UNLIKELY(self->IsExceptionPending())) {
     LOG(WARNING) << "Suppressing exception for non-standard method exit: "
                  << self->GetException()->Dump();
@@ -217,8 +213,7 @@ static inline ALWAYS_INLINE void PerformNonStandardReturn(
   DoMonitorCheckOnExit<kMonitorCounting>(self, &frame);
   result = JValue();
   if (UNLIKELY(NeedsMethodExitEvent(instrumentation))) {
-    SendMethodExitEvents(
-        self, instrumentation, frame, h_thiz.Get(), frame.GetMethod(), dex_pc, result);
+    SendMethodExitEvents(self, instrumentation, frame, frame.GetMethod(), result);
   }
 }
 

--- a/runtime/interpreter/interpreter_switch_impl-inl.h
+++ b/runtime/interpreter/interpreter_switch_impl-inl.h
@@ -64,12 +64,8 @@ class InstructionHandler {
       DCHECK(abort_exception != nullptr);
       DCHECK(abort_exception->GetClass()->DescriptorEquals(Transaction::kAbortExceptionDescriptor));
       Self()->ClearException();
-      PerformNonStandardReturn<kMonitorState>(Self(),
-                                              shadow_frame_,
-                                              ctx_->result,
-                                              Instrumentation(),
-                                              Accessor().InsSize(),
-                                              inst_->GetDexPc(Insns()));
+      PerformNonStandardReturn<kMonitorState>(
+          Self(), shadow_frame_, ctx_->result, Instrumentation(), Accessor().InsSize());
       Self()->SetException(abort_exception.Get());
       ExitInterpreterLoop();
       return false;
@@ -80,12 +76,8 @@ class InstructionHandler {
   HANDLER_ATTRIBUTES bool CheckForceReturn() {
     if (shadow_frame_.GetForcePopFrame()) {
       DCHECK(Runtime::Current()->AreNonStandardExitsEnabled());
-      PerformNonStandardReturn<kMonitorState>(Self(),
-                                              shadow_frame_,
-                                              ctx_->result,
-                                              Instrumentation(),
-                                              Accessor().InsSize(),
-                                              inst_->GetDexPc(Insns()));
+      PerformNonStandardReturn<kMonitorState>(
+          Self(), shadow_frame_, ctx_->result, Instrumentation(), Accessor().InsSize());
       ExitInterpreterLoop();
       return false;
     }
@@ -216,9 +208,7 @@ class InstructionHandler {
                  !SendMethodExitEvents(Self(),
                                        Instrumentation(),
                                        shadow_frame_,
-                                       shadow_frame_.GetThisObject(Accessor().InsSize()),
                                        shadow_frame_.GetMethod(),
-                                       inst_->GetDexPc(Insns()),
                                        result))) {
       DCHECK(Self()->IsExceptionPending());
       // Do not raise exception event if it is caused by other instrumentation event.
@@ -495,9 +485,7 @@ class InstructionHandler {
                  !SendMethodExitEvents(Self(),
                                        Instrumentation(),
                                        shadow_frame_,
-                                       shadow_frame_.GetThisObject(Accessor().InsSize()),
                                        shadow_frame_.GetMethod(),
-                                       inst_->GetDexPc(Insns()),
                                        h_result))) {
       DCHECK(Self()->IsExceptionPending());
       // Do not raise exception event if it is caused by other instrumentation event.

--- a/runtime/interpreter/mterp/arm64ng/main.S
+++ b/runtime/interpreter/mterp/arm64ng/main.S
@@ -61,6 +61,7 @@
  *   reg nick      purpose
  *   x19  xSELF     self (Thread) pointer
  *   x20  wMR       marking register
+ *   x21  xSUSPEND  suspend check register
  *   x29  xFP       interpreted frame pointer, used for accessing locals and args
  *   x22  xPC       interpreted program counter, used for fetching instructions
  *   x23  xINST     first 16-bit code unit of current instruction
@@ -74,7 +75,6 @@
 */
 
 /* single-purpose registers, given names for clarity */
-#define xSELF    x19
 #define CFI_DEX  22 // DWARF register number of the register holding dex-pc (xPC).
 #define CFI_TMP  0  // DWARF register number of the first argument register (r0).
 #define xPC      x22
@@ -461,8 +461,9 @@ END \name
 
     // GP callee-saves.
     // No need to restore x19 (it's always the thread), and
-    // don't restore x20 (the marking register) as it may have been updated.
-    RESTORE_TWO_REGS x21, x22, 80
+    // don't restore x20 (the marking register) as it may have been updated,
+    // don't restore x21 (the suspend check register) as it may have been updated.
+    RESTORE_REG      x22, 88
     RESTORE_TWO_REGS x23, x24, 96
     RESTORE_TWO_REGS x25, x26, 112
     RESTORE_TWO_REGS x27, x28, 128
@@ -1597,12 +1598,12 @@ OAT_ENTRY ExecuteNterpImpl, EndExecuteNterpImpl
 
     sub ip2, ip, x15
     ldr w26, [x0, #ART_METHOD_ACCESS_FLAGS_OFFSET]
-    lsl x21, ip2, #2 // x21 is now the offset for inputs into the registers array.
+    lsl x27, ip2, #2 // x27 is now the offset for inputs into the registers array.
 
     tbz w26, #ART_METHOD_NTERP_ENTRY_POINT_FAST_PATH_FLAG_BIT, .Lsetup_slow_path
     // Setup pointer to inputs in FP and pointer to inputs in REFS
-    add x10, xFP, x21
-    add x11, xREFS, x21
+    add x10, xFP, x27
+    add x11, xREFS, x27
     mov x12, #0
     SETUP_REFERENCE_PARAMETER_IN_GPR w1, x10, x11, w15, x12, .Lxmm_setup_finished
     SETUP_REFERENCE_PARAMETER_IN_GPR w2, x10, x11, w15, x12, .Lxmm_setup_finished
@@ -1619,8 +1620,8 @@ OAT_ENTRY ExecuteNterpImpl, EndExecuteNterpImpl
     // If the method is not static and there is one argument ('this'), we don't need to fetch the
     // shorty.
     tbnz w26, #ART_METHOD_IS_STATIC_FLAG_BIT, .Lsetup_with_shorty
-    str w1, [xFP, x21]
-    str w1, [xREFS, x21]
+    str w1, [xFP, x27]
+    str w1, [xREFS, x27]
     cmp w15, #1
     b.eq .Lxmm_setup_finished
 
@@ -1633,8 +1634,8 @@ OAT_ENTRY ExecuteNterpImpl, EndExecuteNterpImpl
     RESTORE_ALL_ARGUMENTS
 
     // Setup pointer to inputs in FP and pointer to inputs in REFS
-    add x10, xFP, x21
-    add x11, xREFS, x21
+    add x10, xFP, x27
+    add x11, xREFS, x27
     mov x12, #0
 
     add x9, xIBASE, #1  // shorty + 1  ; ie skip return arg character

--- a/runtime/jit/jit.cc
+++ b/runtime/jit/jit.cc
@@ -299,6 +299,19 @@ bool Jit::CompileMethod(ArtMethod* method,
   DCHECK(Runtime::Current()->UseJitCompilation());
   DCHECK(!method->IsRuntimeMethod());
 
+  // If the baseline flag was explicitly passed in the compiler options, change the compilation kind
+  // from optimized to baseline.
+  if (jit_compiler_->IsBaselineCompiler() && compilation_kind == CompilationKind::kOptimized) {
+    compilation_kind = CompilationKind::kBaseline;
+  }
+
+  // If we're asked to compile baseline, but we cannot allocate profiling infos,
+  // change the compilation kind to optimized.
+  if ((compilation_kind == CompilationKind::kBaseline) &&
+      !GetCodeCache()->CanAllocateProfilingInfo()) {
+    compilation_kind = CompilationKind::kOptimized;
+  }
+
   RuntimeCallbacks* cb = Runtime::Current()->GetRuntimeCallbacks();
   // Don't compile the method if it has breakpoints.
   if (cb->IsMethodBeingInspected(method) && !cb->IsMethodSafeToJit(method)) {

--- a/runtime/jit/jit.cc
+++ b/runtime/jit/jit.cc
@@ -241,9 +241,13 @@ Jit* Jit::Create(JitCodeCache* code_cache, JitOptions* options) {
   // With 'perf', we want a 1-1 mapping between an address and a method.
   // We aren't able to keep method pointers live during the instrumentation method entry trampoline
   // so we will just disable jit-gc if we are doing that.
+  // JitAtFirstUse compiles the methods synchronously on mutator threads. While this should work
+  // in theory it is causing deadlocks in some jvmti tests related to Jit GC. Hence, disabling
+  // Jit GC for now (b/147208992).
   if (code_cache->GetGarbageCollectCode()) {
     code_cache->SetGarbageCollectCode(!jit_compiler_->GenerateDebugInfo() &&
-        !Runtime::Current()->GetInstrumentation()->AreExitStubsInstalled());
+        !Runtime::Current()->GetInstrumentation()->AreExitStubsInstalled() &&
+        !jit->JitAtFirstUse());
   }
 
   VLOG(jit) << "JIT created with initial_capacity="
@@ -1709,8 +1713,12 @@ void Jit::PostForkChildAction(bool is_system_server, bool is_zygote) {
   jit_compiler_->ParseCompilerOptions();
 
   // Adjust the status of code cache collection: the status from zygote was to not collect.
+  // JitAtFirstUse compiles the methods synchronously on mutator threads. While this should work
+  // in theory it is causing deadlocks in some jvmti tests related to Jit GC. Hence, disabling
+  // Jit GC for now (b/147208992).
   code_cache_->SetGarbageCollectCode(!jit_compiler_->GenerateDebugInfo() &&
-      !Runtime::Current()->GetInstrumentation()->AreExitStubsInstalled());
+      !Runtime::Current()->GetInstrumentation()->AreExitStubsInstalled() &&
+      !JitAtFirstUse());
 
   if (is_system_server && HasImageWithProfile()) {
     // Disable garbage collection: we don't want it to delete methods we're compiling

--- a/runtime/jit/jit.h
+++ b/runtime/jit/jit.h
@@ -203,6 +203,7 @@ class JitCompilerInterface {
       REQUIRES_SHARED(Locks::mutator_lock_) = 0;
   virtual bool GenerateDebugInfo() = 0;
   virtual void ParseCompilerOptions() = 0;
+  virtual bool IsBaselineCompiler() const;
 
   virtual std::vector<uint8_t> PackElfFileForJIT(ArrayRef<const JITCodeEntry*> elf_files,
                                                  ArrayRef<const void*> removed_symbols,

--- a/runtime/jit/jit_code_cache.cc
+++ b/runtime/jit/jit_code_cache.cc
@@ -1650,7 +1650,8 @@ bool JitCodeCache::NotifyCompilationOf(ArtMethod* method,
     }
     return new_compilation;
   } else {
-    if (CanAllocateProfilingInfo() && (compilation_kind == CompilationKind::kBaseline)) {
+    if (compilation_kind == CompilationKind::kBaseline) {
+      DCHECK(CanAllocateProfilingInfo());
       bool has_profiling_info = false;
       {
         MutexLock mu(self, *Locks::jit_lock_);

--- a/runtime/jni/jni_env_ext.cc
+++ b/runtime/jni/jni_env_ext.cc
@@ -151,23 +151,23 @@ static size_t JNIEnvSize(size_t pointer_size) {
   return pointer_size;
 }
 
-Offset JNIEnvExt::SegmentStateOffset(size_t pointer_size) {
+MemberOffset JNIEnvExt::SegmentStateOffset(size_t pointer_size) {
   size_t locals_offset = JNIEnvSize(pointer_size) +
                          2 * pointer_size +          // Thread* self + JavaVMExt* vm.
                          4 +                         // local_ref_cookie.
                          (pointer_size - 4);         // Padding.
   size_t irt_segment_state_offset =
       IndirectReferenceTable::SegmentStateOffset(pointer_size).Int32Value();
-  return Offset(locals_offset + irt_segment_state_offset);
+  return MemberOffset(locals_offset + irt_segment_state_offset);
 }
 
-Offset JNIEnvExt::LocalRefCookieOffset(size_t pointer_size) {
-  return Offset(JNIEnvSize(pointer_size) +
-                2 * pointer_size);          // Thread* self + JavaVMExt* vm
+MemberOffset JNIEnvExt::LocalRefCookieOffset(size_t pointer_size) {
+  return MemberOffset(JNIEnvSize(pointer_size) +
+                      2 * pointer_size);          // Thread* self + JavaVMExt* vm
 }
 
-Offset JNIEnvExt::SelfOffset(size_t pointer_size) {
-  return Offset(JNIEnvSize(pointer_size));
+MemberOffset JNIEnvExt::SelfOffset(size_t pointer_size) {
+  return MemberOffset(JNIEnvSize(pointer_size));
 }
 
 // Use some defining part of the caller's frame as the identifying mark for the JNI segment.

--- a/runtime/jni/jni_env_ext.cc
+++ b/runtime/jni/jni_env_ext.cc
@@ -77,7 +77,7 @@ JNIEnvExt::JNIEnvExt(Thread* self_in, JavaVMExt* vm_in, std::string* error_msg)
     : self_(self_in),
       vm_(vm_in),
       local_ref_cookie_(kIRTFirstSegment),
-      locals_(kLocalsInitial, kLocal, IndirectReferenceTable::ResizableCapacity::kYes, error_msg),
+      locals_(1, kLocal, IndirectReferenceTable::ResizableCapacity::kYes, error_msg),
       monitors_("monitors", kMonitorsInitial, kMonitorsMax),
       critical_(0),
       check_jni_(false),

--- a/runtime/jni/jni_env_ext.h
+++ b/runtime/jni/jni_env_ext.h
@@ -37,10 +37,6 @@ namespace mirror {
 class Object;
 }  // namespace mirror
 
-// Number of local references in the indirect reference table. The value is arbitrary but
-// low enough that it forces integrity checks.
-static constexpr size_t kLocalsInitial = 512;
-
 class JNIEnvExt : public JNIEnv {
  public:
   // Creates a new JNIEnvExt. Returns null on error, in which case error_msg

--- a/runtime/jni/jni_env_ext.h
+++ b/runtime/jni/jni_env_ext.h
@@ -46,9 +46,9 @@ class JNIEnvExt : public JNIEnv {
   // Creates a new JNIEnvExt. Returns null on error, in which case error_msg
   // will contain a description of the error.
   static JNIEnvExt* Create(Thread* self, JavaVMExt* vm, std::string* error_msg);
-  static Offset SegmentStateOffset(size_t pointer_size);
-  static Offset LocalRefCookieOffset(size_t pointer_size);
-  static Offset SelfOffset(size_t pointer_size);
+  static MemberOffset SegmentStateOffset(size_t pointer_size);
+  static MemberOffset LocalRefCookieOffset(size_t pointer_size);
+  static MemberOffset SelfOffset(size_t pointer_size);
   static jint GetEnvHandler(JavaVMExt* vm, /*out*/void** out, jint version);
 
   ~JNIEnvExt();

--- a/runtime/mirror/object.h
+++ b/runtime/mirror/object.h
@@ -71,7 +71,7 @@ class Throwable;
 static constexpr bool kCheckFieldAssignments = false;
 
 // Size of Object.
-static constexpr uint32_t kObjectHeaderSize = kUseBrooksReadBarrier ? 16 : 8;
+static constexpr uint32_t kObjectHeaderSize = 8;
 
 // C++ mirror of java.lang.Object
 class MANAGED LOCKABLE Object {
@@ -774,14 +774,6 @@ class MANAGED LOCKABLE Object {
   HeapReference<Class> klass_;
   // Monitor and hash code information.
   uint32_t monitor_;
-
-#ifdef USE_BROOKS_READ_BARRIER
-  // Note names use a 'x' prefix and the x_rb_ptr_ is of type int
-  // instead of Object to go with the alphabetical/by-type field order
-  // on the Java side.
-  uint32_t x_rb_ptr_;      // For the Brooks pointer.
-  uint32_t x_xpadding_;    // For 8-byte alignment. TODO: get rid of this.
-#endif
 
   friend class art::Monitor;
   friend struct art::ObjectOffsets;  // for verifying offset information

--- a/runtime/native/dalvik_system_VMRuntime.cc
+++ b/runtime/native/dalvik_system_VMRuntime.cc
@@ -161,6 +161,10 @@ static jlong VMRuntime_addressOf(JNIEnv* env, jobject, jobject javaArray) {
     ThrowIllegalArgumentException("not an array");
     return 0;
   }
+  if (array->IsObjectArray()) {
+    ThrowIllegalArgumentException("not a primitive array");
+    return 0;
+  }
   if (Runtime::Current()->GetHeap()->IsMovableObject(array)) {
     ThrowRuntimeException("Trying to get address of movable array object");
     return 0;

--- a/runtime/oat.h
+++ b/runtime/oat.h
@@ -32,8 +32,8 @@ class InstructionSetFeatures;
 class PACKED(4) OatHeader {
  public:
   static constexpr std::array<uint8_t, 4> kOatMagic { { 'o', 'a', 't', '\n' } };
-  // Last oat version changed reason: Disable partial LSE b/197818595.
-  static constexpr std::array<uint8_t, 4> kOatVersion { { '1', '9', '9', '\0' } };
+  // Last oat version changed reason: Inline IRT frame push/pop into JNI stubs.
+  static constexpr std::array<uint8_t, 4> kOatVersion { { '2', '0', '3', '\0' } };
 
   static constexpr const char* kDex2OatCmdLineKey = "dex2oat-cmdline";
   static constexpr const char* kDebuggableKey = "debuggable";

--- a/runtime/oat.h
+++ b/runtime/oat.h
@@ -32,8 +32,8 @@ class InstructionSetFeatures;
 class PACKED(4) OatHeader {
  public:
   static constexpr std::array<uint8_t, 4> kOatMagic { { 'o', 'a', 't', '\n' } };
-  // Last oat version changed reason: Inline IRT frame push/pop into JNI stubs.
-  static constexpr std::array<uint8_t, 4> kOatVersion { { '2', '0', '3', '\0' } };
+  // Last oat version changed reason: ARM64: Implicit null checks using LDR.
+  static constexpr std::array<uint8_t, 4> kOatVersion { { '2', '1', '5', '\0' } };
 
   static constexpr const char* kDex2OatCmdLineKey = "dex2oat-cmdline";
   static constexpr const char* kDebuggableKey = "debuggable";

--- a/runtime/oat_file_manager.cc
+++ b/runtime/oat_file_manager.cc
@@ -390,9 +390,11 @@ std::vector<std::unique_ptr<const DexFile>> OatFileManager::OpenDexFilesFromOat(
     static constexpr bool kVerifyChecksum = true;
     const ArtDexFileLoader dex_file_loader;
     int fd;
+    int old_fd = 0;
     if (!strncmp("/proc/self/fd/", dex_location, strlen("/proc/self/fd/")) &&
           sscanf(dex_location, "/proc/self/fd/%d", &fd) == 1) {
-      fd = dup(fd);
+      fd = open(dex_location, O_CLOEXEC | O_RDONLY);
+      lseek(fd, lseek(old_fd, 0, SEEK_CUR), 0);
     } else {
       fd = open(dex_location, O_RDONLY | O_CLOEXEC);
     }

--- a/runtime/read_barrier-inl.h
+++ b/runtime/read_barrier-inl.h
@@ -72,9 +72,6 @@ inline MirrorType* ReadBarrier::Barrier(
       }
       AssertToSpaceInvariant(obj, offset, ref);
       return ref;
-    } else if (kUseBrooksReadBarrier) {
-      // To be implemented.
-      return ref_addr->template AsMirrorPtr<kIsVolatile>();
     } else if (kUseTableLookupReadBarrier) {
       MirrorType* ref = ref_addr->template AsMirrorPtr<kIsVolatile>();
       MirrorType* old_ref = ref;
@@ -123,9 +120,6 @@ inline MirrorType* ReadBarrier::BarrierForRoot(MirrorType** root,
       }
       AssertToSpaceInvariant(gc_root_source, ref);
       return ref;
-    } else if (kUseBrooksReadBarrier) {
-      // To be implemented.
-      return ref;
     } else if (kUseTableLookupReadBarrier) {
       Thread* self = Thread::Current();
       if (self != nullptr &&
@@ -163,9 +157,6 @@ inline MirrorType* ReadBarrier::BarrierForRoot(mirror::CompressedReference<Mirro
       ref = reinterpret_cast<MirrorType*>(Mark(ref));
     }
     AssertToSpaceInvariant(gc_root_source, ref);
-    return ref;
-  } else if (with_read_barrier && kUseBrooksReadBarrier) {
-    // To be implemented.
     return ref;
   } else if (with_read_barrier && kUseTableLookupReadBarrier) {
     Thread* self = Thread::Current();

--- a/runtime/read_barrier_config.h
+++ b/runtime/read_barrier_config.h
@@ -24,14 +24,12 @@
 // Global (C) part.
 
 // Uncomment one of the following two and the two fields in
-// Object.java (libcore) to enable baker, brooks (unimplemented), or
+// Object.java (libcore) to enable baker, or
 // table-lookup read barriers.
 
 #ifdef ART_USE_READ_BARRIER
 #if ART_READ_BARRIER_TYPE_IS_BAKER
 #define USE_BAKER_READ_BARRIER
-#elif ART_READ_BARRIER_TYPE_IS_BROOKS
-#define USE_BROOKS_READ_BARRIER
 #elif ART_READ_BARRIER_TYPE_IS_TABLELOOKUP
 #define USE_TABLE_LOOKUP_READ_BARRIER
 #else
@@ -39,16 +37,8 @@
 #endif
 #endif  // ART_USE_READ_BARRIER
 
-#if defined(USE_BAKER_READ_BARRIER) || defined(USE_BROOKS_READ_BARRIER)
-#define USE_BAKER_OR_BROOKS_READ_BARRIER
-#endif
-
-#if defined(USE_BAKER_READ_BARRIER) || defined(USE_BROOKS_READ_BARRIER) || defined(USE_TABLE_LOOKUP_READ_BARRIER)
+#if defined(USE_BAKER_READ_BARRIER) || defined(USE_TABLE_LOOKUP_READ_BARRIER)
 #define USE_READ_BARRIER
-#endif
-
-#if defined(USE_BAKER_READ_BARRIER) && defined(USE_BROOKS_READ_BARRIER)
-#error "Only one of Baker or Brooks can be enabled at a time."
 #endif
 
 
@@ -64,21 +54,13 @@ static constexpr bool kUseBakerReadBarrier = true;
 static constexpr bool kUseBakerReadBarrier = false;
 #endif
 
-#ifdef USE_BROOKS_READ_BARRIER
-static constexpr bool kUseBrooksReadBarrier = true;
-#else
-static constexpr bool kUseBrooksReadBarrier = false;
-#endif
-
 #ifdef USE_TABLE_LOOKUP_READ_BARRIER
 static constexpr bool kUseTableLookupReadBarrier = true;
 #else
 static constexpr bool kUseTableLookupReadBarrier = false;
 #endif
 
-static constexpr bool kUseBakerOrBrooksReadBarrier = kUseBakerReadBarrier || kUseBrooksReadBarrier;
-static constexpr bool kUseReadBarrier =
-    kUseBakerReadBarrier || kUseBrooksReadBarrier || kUseTableLookupReadBarrier;
+static constexpr bool kUseReadBarrier = kUseBakerReadBarrier || kUseTableLookupReadBarrier;
 
 // Debugging flag that forces the generation of read barriers, but
 // does not trigger the use of the concurrent copying GC.

--- a/runtime/runtime.cc
+++ b/runtime/runtime.cc
@@ -89,6 +89,7 @@
 #include "handle_scope-inl.h"
 #include "hidden_api.h"
 #include "image-inl.h"
+#include "indirect_reference_table.h"
 #include "instrumentation.h"
 #include "intern_table-inl.h"
 #include "interpreter/interpreter.h"
@@ -497,6 +498,8 @@ Runtime::~Runtime() {
   monitor_pool_ = nullptr;
   delete class_linker_;
   class_linker_ = nullptr;
+  delete small_irt_allocator_;
+  small_irt_allocator_ = nullptr;
   delete heap_;
   heap_ = nullptr;
   delete intern_table_;
@@ -1661,6 +1664,8 @@ bool Runtime::Init(RuntimeArgumentMap&& runtime_options_in) {
     low_4gb_arena_pool_.reset(new MemMapArenaPool(/* low_4gb= */ true));
   }
   linear_alloc_.reset(CreateLinearAlloc());
+
+  small_irt_allocator_ = new SmallIrtAllocator();
 
   BlockSignals();
   InitPlatformSignalHandlers();

--- a/runtime/runtime.cc
+++ b/runtime/runtime.cc
@@ -1672,10 +1672,12 @@ bool Runtime::Init(RuntimeArgumentMap&& runtime_options_in) {
 
   // Change the implicit checks flags based on runtime architecture.
   switch (kRuntimeISA) {
+    case InstructionSet::kArm64:
+      implicit_suspend_checks_ = true;
+      FALLTHROUGH_INTENDED;
     case InstructionSet::kArm:
     case InstructionSet::kThumb2:
     case InstructionSet::kX86:
-    case InstructionSet::kArm64:
     case InstructionSet::kX86_64:
       implicit_null_checks_ = true;
       // Historical note: Installing stack protection was not playing well with Valgrind.

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -106,6 +106,7 @@ class Plugin;
 struct RuntimeArgumentMap;
 class RuntimeCallbacks;
 class SignalCatcher;
+class SmallIrtAllocator;
 class StackOverflowHandler;
 class SuspensionHandler;
 class ThreadList;
@@ -305,6 +306,10 @@ class Runtime {
 
   ClassLinker* GetClassLinker() const {
     return class_linker_;
+  }
+
+  SmallIrtAllocator* GetSmallIrtAllocator() const {
+    return small_irt_allocator_;
   }
 
   jni::JniIdManager* GetJniIdManager() const {
@@ -1172,6 +1177,8 @@ class Runtime {
   ClassLinker* class_linker_;
 
   SignalCatcher* signal_catcher_;
+
+  SmallIrtAllocator* small_irt_allocator_;
 
   std::unique_ptr<jni::JniIdManager> jni_id_manager_;
 

--- a/runtime/trace.cc
+++ b/runtime/trace.cc
@@ -741,9 +741,7 @@ void Trace::MethodEntered(Thread* thread, ArtMethod* method) {
 }
 
 void Trace::MethodExited(Thread* thread,
-                         Handle<mirror::Object> this_object ATTRIBUTE_UNUSED,
                          ArtMethod* method,
-                         uint32_t dex_pc ATTRIBUTE_UNUSED,
                          instrumentation::OptionalFrame frame ATTRIBUTE_UNUSED,
                          JValue& return_value ATTRIBUTE_UNUSED) {
   uint32_t thread_clock_diff = 0;

--- a/runtime/trace.cc
+++ b/runtime/trace.cc
@@ -732,10 +732,7 @@ void Trace::FieldWritten(Thread* thread ATTRIBUTE_UNUSED,
              << " " << dex_pc;
 }
 
-void Trace::MethodEntered(Thread* thread,
-                          Handle<mirror::Object> this_object ATTRIBUTE_UNUSED,
-                          ArtMethod* method,
-                          uint32_t dex_pc ATTRIBUTE_UNUSED) {
+void Trace::MethodEntered(Thread* thread, ArtMethod* method) {
   uint32_t thread_clock_diff = 0;
   uint32_t wall_clock_diff = 0;
   ReadClocks(thread, &thread_clock_diff, &wall_clock_diff);

--- a/runtime/trace.h
+++ b/runtime/trace.h
@@ -175,12 +175,8 @@ class Trace final : public instrumentation::InstrumentationListener {
       REQUIRES_SHARED(Locks::mutator_lock_) REQUIRES(!unique_methods_lock_, !streaming_lock_);
 
   // InstrumentationListener implementation.
-  void MethodEntered(Thread* thread,
-                     Handle<mirror::Object> this_object,
-                     ArtMethod* method,
-                     uint32_t dex_pc)
-      REQUIRES_SHARED(Locks::mutator_lock_) REQUIRES(!unique_methods_lock_, !streaming_lock_)
-      override;
+  void MethodEntered(Thread* thread, ArtMethod* method) REQUIRES_SHARED(Locks::mutator_lock_)
+      REQUIRES(!unique_methods_lock_, !streaming_lock_) override;
   void MethodExited(Thread* thread,
                     Handle<mirror::Object> this_object,
                     ArtMethod* method,

--- a/runtime/trace.h
+++ b/runtime/trace.h
@@ -178,9 +178,7 @@ class Trace final : public instrumentation::InstrumentationListener {
   void MethodEntered(Thread* thread, ArtMethod* method) REQUIRES_SHARED(Locks::mutator_lock_)
       REQUIRES(!unique_methods_lock_, !streaming_lock_) override;
   void MethodExited(Thread* thread,
-                    Handle<mirror::Object> this_object,
                     ArtMethod* method,
-                    uint32_t dex_pc,
                     instrumentation::OptionalFrame frame,
                     JValue& return_value)
       REQUIRES_SHARED(Locks::mutator_lock_) REQUIRES(!unique_methods_lock_, !streaming_lock_)

--- a/test/706-checker-scheduler/src/Main.java
+++ b/test/706-checker-scheduler/src/Main.java
@@ -610,11 +610,11 @@ public class Main {
   /// CHECK:     beq
 
   /// CHECK-START-ARM64: void Main.testCrossItersDependencies() disassembly (after)
+  /// CHECK:     ldr
   /// CHECK:     sub
   /// CHECK:     add
   /// CHECK:     add
-  /// CHECK:     ldrh
-  /// CHECK:     cbz
+  /// CHECK:     b
   private static void testCrossItersDependencies() {
     int[] data = {1, 2, 3, 0};
     int sub = 0;

--- a/tools/cpp-define-generator/thread.def
+++ b/tools/cpp-define-generator/thread.def
@@ -65,6 +65,8 @@ ASM_DEFINE(THREAD_USE_MTERP_OFFSET,
            art::Thread::UseMterpOffset<art::kRuntimePointerSize>().Int32Value())
 ASM_DEFINE(THREAD_TOP_QUICK_FRAME_OFFSET,
            art::Thread::TopOfManagedStackOffset<art::kRuntimePointerSize>().Int32Value())
+ASM_DEFINE(THREAD_SUSPEND_TRIGGER_OFFSET,
+           art::Thread::ThreadSuspendTriggerOffset<art::kRuntimePointerSize>().Int32Value())
 ASM_DEFINE(THREAD_ALLOC_OBJECT_ENTRYPOINT_OFFSET,
            art::GetThreadOffset<art::kRuntimePointerSize>(art::kQuickAllocObjectInitialized)
                .Int32Value())

--- a/tools/tracefast-plugin/tracefast.cc
+++ b/tools/tracefast-plugin/tracefast.cc
@@ -48,17 +48,13 @@ class Tracer final : public art::instrumentation::InstrumentationListener {
       REQUIRES_SHARED(art::Locks::mutator_lock_) {}
 
   void MethodExited(art::Thread* thread ATTRIBUTE_UNUSED,
-                    art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,
                     art::ArtMethod* method ATTRIBUTE_UNUSED,
-                    uint32_t dex_pc ATTRIBUTE_UNUSED,
                     art::instrumentation::OptionalFrame frame ATTRIBUTE_UNUSED,
                     art::MutableHandle<art::mirror::Object>& return_value ATTRIBUTE_UNUSED)
       override REQUIRES_SHARED(art::Locks::mutator_lock_) { }
 
   void MethodExited(art::Thread* thread ATTRIBUTE_UNUSED,
-                    art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,
                     art::ArtMethod* method ATTRIBUTE_UNUSED,
-                    uint32_t dex_pc ATTRIBUTE_UNUSED,
                     art::instrumentation::OptionalFrame frame ATTRIBUTE_UNUSED,
                     art::JValue& return_value ATTRIBUTE_UNUSED)
       override REQUIRES_SHARED(art::Locks::mutator_lock_) { }

--- a/tools/tracefast-plugin/tracefast.cc
+++ b/tools/tracefast-plugin/tracefast.cc
@@ -44,10 +44,8 @@ class Tracer final : public art::instrumentation::InstrumentationListener {
   Tracer() {}
 
   void MethodEntered(art::Thread* thread ATTRIBUTE_UNUSED,
-                     art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,
-                     art::ArtMethod* method ATTRIBUTE_UNUSED,
-                     uint32_t dex_pc ATTRIBUTE_UNUSED)
-      override REQUIRES_SHARED(art::Locks::mutator_lock_) { }
+                     art::ArtMethod* method ATTRIBUTE_UNUSED) override
+      REQUIRES_SHARED(art::Locks::mutator_lock_) {}
 
   void MethodExited(art::Thread* thread ATTRIBUTE_UNUSED,
                     art::Handle<art::mirror::Object> this_object ATTRIBUTE_UNUSED,


### PR DESCRIPTION
Signed-off-by: Matt Filetto <matt.filetto@gmail.com>

Applied the suggested changes by LSPosed devs to fix LSPosed not launching a 2nd time (LSPosed Dev message below)

===
We recently received many complaints from users that they cannot launch the LSPosed manager the second time. This is because the third-party ROM they use has merged this PR (https://github.com/GrapheneOS/platform_art/pull/1). This is totally wrong and breaks the behavior of standard SDK: the fd changes its offset after calling an open interface. We don't fix this on our side. Please ask your ROM maintainer to revert this commit or fix this commit (open + setoffset instead of dupping the fd). Or switch to another ROM.
===

